### PR TITLE
Add `okta apps delete` command

### DIFF
--- a/cli/src/main/java/com/okta/cli/Environment.java
+++ b/cli/src/main/java/com/okta/cli/Environment.java
@@ -34,6 +34,8 @@ public class Environment {
 
     private boolean interactive = true;
 
+    private boolean verbose = false;
+
     private boolean consoleColors = true;
 
     public boolean isInteractive() {
@@ -48,6 +50,14 @@ public class Environment {
     public Environment setConsoleColors(boolean consoleColors) {
         this.consoleColors = consoleColors;
         return this;
+    }
+
+    public boolean isVerbose() {
+        return verbose;
+    }
+
+    public void setVerbose(boolean verbose) {
+        this.verbose = verbose;
     }
 
     public File workingDirectory() {

--- a/cli/src/main/java/com/okta/cli/OktaCli.java
+++ b/cli/src/main/java/com/okta/cli/OktaCli.java
@@ -98,8 +98,6 @@ public class OktaCli implements Runnable {
 
         private final static Environment environment = new Environment();
 
-        private boolean verbose = false;
-
         @Option(names = "--color", hidden = true) // gnu tools use --color=always,never,auto (for not just support always and never)
         public void setColor(ColorOptions color) {
             environment.setConsoleColors(color == ColorOptions.always);
@@ -112,14 +110,14 @@ public class OktaCli implements Runnable {
 
         @Option(names = "--verbose", description = "Verbose logging")
         public void setVerbose(boolean verbose) {
-            this.verbose = verbose;
+            this.environment.setVerbose(verbose);
             if (verbose) {
                 System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "debug");
             }
         }
 
         public boolean isVerbose() {
-            return verbose;
+            return getEnvironment().isVerbose();
         }
 
         @Option(names = "-D", hidden = true, description = "Set Java System Property key value pairs", paramLabel = "<key=value>")

--- a/cli/src/main/java/com/okta/cli/commands/apps/Apps.java
+++ b/cli/src/main/java/com/okta/cli/commands/apps/Apps.java
@@ -23,7 +23,8 @@ import picocli.CommandLine.Command;
          description = "Manage Okta apps",
          subcommands = {
                     AppsConfig.class,
-                    AppsCreate.class})
+                    AppsCreate.class,
+                    AppsDelete.class})
 public class Apps extends BaseCommand {
 
     @Override

--- a/cli/src/main/java/com/okta/cli/commands/apps/AppsDelete.java
+++ b/cli/src/main/java/com/okta/cli/commands/apps/AppsDelete.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.cli.commands.apps;
+
+import com.okta.cli.commands.BaseCommand;
+import com.okta.cli.console.ConsoleOutput;
+import com.okta.sdk.client.Client;
+import com.okta.sdk.client.Clients;
+import com.okta.sdk.resource.ResourceException;
+import com.okta.sdk.resource.application.Application;
+import picocli.CommandLine;
+
+import java.util.List;
+
+@CommandLine.Command(name = "delete",
+        description = "Deletes an Okta app")
+public class AppsDelete extends BaseCommand {
+
+    @CommandLine.Parameters(index="0..*", arity = "1..*", description = "List of application IDs to be deleted")
+    private List<String> appIds;
+
+    @CommandLine.Option(names = {"-f", "--force"}, description = "Deactivate and delete applications")
+    private boolean force = false;
+
+    @Override
+    public int runCommand() throws Exception {
+
+        int exitCode = 0;
+        ConsoleOutput out = getConsoleOutput();
+
+        Client client = Clients.builder().build();
+
+        for(String id : appIds) {
+            try {
+                // try to delete each one, ignoring errors, this is similar to how `docker rmi` works
+                if (!deleteApp(client.getApplication(id))) {
+                    exitCode = 1;
+                }
+            } catch (ResourceException e) {
+                out.writeLine("Failed to delete application: '" + id + "':");
+                out.writeLine("  " + e.getMessage());
+                if (getEnvironment().isVerbose()) {
+                    e.printStackTrace();
+                }
+                exitCode = 1;
+            }
+        }
+
+        return exitCode;
+    }
+
+    private boolean deleteApp(Application app) {
+        ConsoleOutput out = getConsoleOutput();
+
+        // application already deleted
+        if (Application.StatusEnum.DELETED.equals(app.getStatus())) {
+            out.writeLine("Application '" + app.getId() + "' has already been marked for deletion");
+            return false;
+        }
+
+        // Not interactive or --force
+        if (!force && !getEnvironment().isInteractive()) {
+            out.writeLine("Application '" + app.getId() + "' has not been deactivated, use '--force' to delete it");
+            return false;
+        }
+
+        // prompt if needed
+        if (force || getPrompter()
+                 .promptYesNo("Deactivate and delete application '" + app.getId() + "'?", false)) {
+
+            if (Application.StatusEnum.ACTIVE.equals(app.getStatus())) {
+                app.deactivate();
+            }
+            app.delete();
+            out.writeLine("Application '" + app.getId() + "' has been deleted");
+            return true;
+        }
+        return false;
+    }
+}

--- a/integration-tests/src/test/groovy/com/okta/cli/test/AppsCreateIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/cli/test/AppsCreateIT.groovy
@@ -74,9 +74,9 @@ class AppsCreateIT implements MockWebSupport, CreateAppSupport {
                                         null)
 
             verify(mockWebServer.takeRequest(), "GET", "/api/v1/authorizationServers")
-            verify(mockWebServer.takeRequest(), "GET", "/api/v1/apps?q=test-project")
+            verify(mockWebServer.takeRequest(), "GET", "/api/v1/apps", "q=test-project")
             verifyRedirectUri(mockWebServer.takeRequest(), "http://localhost:8080/callback")
-            verify(mockWebServer.takeRequest(), "GET", "/api/v1/groups?q=everyone")
+            verify(mockWebServer.takeRequest(), "GET", "/api/v1/groups", "q=everyone")
             verify(mockWebServer.takeRequest(), "PUT", "/api/v1/apps/test-app-id/groups/every1-id")
             verify(mockWebServer.takeRequest(), "GET", "/api/v1/internal/apps/test-app-id/settings/clientcreds")
             verify(mockWebServer.takeRequest(), "GET", "/api/v1/trustedOrigins")
@@ -262,14 +262,14 @@ class AppsCreateIT implements MockWebSupport, CreateAppSupport {
         }
     }
 
-    private static void verifyRedirectUri(RecordedRequest request, String... expectedRedirectUris) {
+    private void verifyRedirectUri(RecordedRequest request, String... expectedRedirectUris) {
         verify(request, "POST", "/api/v1/apps")
         def body = new JsonSlurper().parse(request.getBody().inputStream())
         String[] redirectUris = body.settings.oauthClient.redirect_uris
         assertThat redirectUris, equalTo(expectedRedirectUris)
     }
 
-    private static void verifyTrustedOrigins(RecordedRequest request, String expectedUri) {
+    private void verifyTrustedOrigins(RecordedRequest request, String expectedUri) {
         verify(request, "POST", "/api/v1/trustedOrigins")
         def body = new JsonSlurper().parse(request.getBody().inputStream())
         assertThat body.origin, equalTo(expectedUri)

--- a/integration-tests/src/test/groovy/com/okta/cli/test/AppsCreateIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/cli/test/AppsCreateIT.groovy
@@ -262,11 +262,6 @@ class AppsCreateIT implements MockWebSupport, CreateAppSupport {
         }
     }
 
-    private static void verify(RecordedRequest request, String method, String relativeUri) {
-        assertThat request.requestUrl.toString(), containsString(relativeUri)
-        assertThat request.method, equalTo(method)
-    }
-
     private static void verifyRedirectUri(RecordedRequest request, String... expectedRedirectUris) {
         verify(request, "POST", "/api/v1/apps")
         def body = new JsonSlurper().parse(request.getBody().inputStream())

--- a/integration-tests/src/test/groovy/com/okta/cli/test/AppsDeleteIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/cli/test/AppsDeleteIT.groovy
@@ -1,0 +1,41 @@
+package com.okta.cli.test
+
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.testng.annotations.Test
+
+import static com.okta.cli.test.CommandRunner.resultMatches
+import static org.hamcrest.MatcherAssert.assertThat
+
+class AppsDeleteIT implements MockWebSupport, CreateAppSupport {
+
+    @Test
+    void deleteMissingApp() {
+
+        MockWebServer mockWebServer = createMockServer()
+        List<MockResponse> responses = [
+                jsonRequest('{}')
+        ]
+
+        mockWebServer.with {
+            responses.forEach { mockWebServer.enqueue(it) }
+
+            List<String> input = [
+//                    "",  // default of "test-project"
+//                    "2", // type of app choice "spa"
+//                    "",  // default callback "http://localhost:8080/callback"
+//                    "",  // default post logout redirect
+            ]
+
+            def result = new CommandRunner()
+                    .withSdkConfig(mockWebServer.url("/").toString())
+                    .runCommandWithInput(input, "--color=never", "apps", "delete", "app-id1")
+
+            assertThat result, resultMatches(0, null,
+                    null)
+
+            verify(mockWebServer.takeRequest(), "GET", "/api/v1/apps/app-id1")
+
+        }
+    }
+}

--- a/integration-tests/src/test/groovy/com/okta/cli/test/AppsDeleteIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/cli/test/AppsDeleteIT.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.okta.cli.test
 
 import okhttp3.mockwebserver.MockResponse
@@ -6,36 +21,219 @@ import org.testng.annotations.Test
 
 import static com.okta.cli.test.CommandRunner.resultMatches
 import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.allOf
+import static org.hamcrest.Matchers.containsString
+import static org.hamcrest.Matchers.equalTo
+import static org.hamcrest.Matchers.not
 
 class AppsDeleteIT implements MockWebSupport, CreateAppSupport {
 
     @Test
-    void deleteMissingApp() {
-
+    void deleteActiveApp() {
         MockWebServer mockWebServer = createMockServer()
         List<MockResponse> responses = [
-                jsonRequest('{}')
+                jsonRequest('{"id": "app-id1", "status": "ACTIVE"}'),
+                new MockResponse().setResponseCode(204),
+                new MockResponse().setResponseCode(204)
         ]
 
         mockWebServer.with {
             responses.forEach { mockWebServer.enqueue(it) }
 
             List<String> input = [
-//                    "",  // default of "test-project"
-//                    "2", // type of app choice "spa"
-//                    "",  // default callback "http://localhost:8080/callback"
-//                    "",  // default post logout redirect
+                    "y"
             ]
 
             def result = new CommandRunner()
                     .withSdkConfig(mockWebServer.url("/").toString())
-                    .runCommandWithInput(input, "--color=never", "apps", "delete", "app-id1")
+                    .runCommandWithInput(input, "--color=never", "apps", "delete", "--verbose", "app-id1")
 
-            assertThat result, resultMatches(0, null,
+            assertThat result, resultMatches(0, allOf(
+                    containsString("Deactivate and delete application 'app-id1'? [y/N]"),
+                    containsString("Application 'app-id1' has been deleted")),
                     null)
 
             verify(mockWebServer.takeRequest(), "GET", "/api/v1/apps/app-id1")
+            verify(mockWebServer.takeRequest(), "POST", "/api/v1/apps/app-id1/lifecycle/deactivate")
+            verify(mockWebServer.takeRequest(), "DELETE", "/api/v1/apps/app-id1")
+            assertThat mockWebServer.requestCount, equalTo(3)
+        }
+    }
+    @Test
+    void forceDeleteActiveApp() {
+        MockWebServer mockWebServer = createMockServer()
+        List<MockResponse> responses = [
+                jsonRequest('{"id": "app-id1", "status": "ACTIVE"}'),
+                new MockResponse().setResponseCode(204),
+                new MockResponse().setResponseCode(204)
+        ]
 
+        mockWebServer.with {
+            responses.forEach { mockWebServer.enqueue(it) }
+
+            List<String> input = []
+
+            def result = new CommandRunner()
+                    .withSdkConfig(mockWebServer.url("/").toString())
+                    .runCommandWithInput(input, "--color=never", "apps", "delete", "--force", "app-id1")
+
+            assertThat result, resultMatches(0, allOf(
+                    not(containsString("Deactivate and delete application 'app-id1'? [y/N]")),
+                    containsString("Application 'app-id1' has been deleted")),
+                    null)
+
+            verify(mockWebServer.takeRequest(), "GET", "/api/v1/apps/app-id1")
+            verify(mockWebServer.takeRequest(), "POST", "/api/v1/apps/app-id1/lifecycle/deactivate")
+            verify(mockWebServer.takeRequest(), "DELETE", "/api/v1/apps/app-id1")
+            assertThat mockWebServer.requestCount, equalTo(3)
+        }
+    }
+
+
+    @Test
+    void deleteInactiveApp() {
+        MockWebServer mockWebServer = createMockServer()
+        List<MockResponse> responses = [
+                jsonRequest('{"id": "app-id1", "status": "INACTIVE"}'),
+                new MockResponse().setResponseCode(204)
+        ]
+
+        mockWebServer.with {
+            responses.forEach { mockWebServer.enqueue(it) }
+
+            List<String> input = [
+                    "y"
+            ]
+
+            def result = new CommandRunner()
+                    .withSdkConfig(mockWebServer.url("/").toString())
+                    .runCommandWithInput(input, "--color=never", "apps", "delete", "--verbose", "app-id1")
+
+            assertThat result, resultMatches(0, allOf(
+                        containsString("Deactivate and delete application 'app-id1'? [y/N]"),
+                        containsString("Application 'app-id1' has been deleted")),
+                    null)
+
+            verify(mockWebServer.takeRequest(), "GET", "/api/v1/apps/app-id1")
+            verify(mockWebServer.takeRequest(), "DELETE", "/api/v1/apps/app-id1")
+            assertThat mockWebServer.requestCount, equalTo(2)
+        }
+    }
+
+    @Test
+    void deleteAlreadyDeletedApp() {
+        MockWebServer mockWebServer = createMockServer()
+        List<MockResponse> responses = [
+                jsonRequest('{"id": "app-id1", "status": "DELETED"}')
+        ]
+
+        mockWebServer.with {
+            responses.forEach { mockWebServer.enqueue(it) }
+
+            List<String> input = []
+
+            def result = new CommandRunner()
+                    .withSdkConfig(mockWebServer.url("/").toString())
+                    .runCommandWithInput(input, "--color=never", "apps", "delete", "--verbose", "app-id1")
+
+            assertThat result, resultMatches(1, containsString("Application 'app-id1' has already been marked for deletion"),
+                    null)
+
+            verify(mockWebServer.takeRequest(), "GET", "/api/v1/apps/app-id1")
+            assertThat mockWebServer.requestCount, equalTo(1)
+        }
+    }
+
+    @Test
+    void cancelDeleteApp() {
+        MockWebServer mockWebServer = createMockServer()
+        List<MockResponse> responses = [
+                jsonRequest('{"id": "app-id1", "status": "ACTIVE"}'),
+                new MockResponse().setResponseCode(204)
+        ]
+
+        mockWebServer.with {
+            responses.forEach { mockWebServer.enqueue(it) }
+
+            List<String> input = [
+                    "n"
+            ]
+
+            def result = new CommandRunner()
+                    .withSdkConfig(mockWebServer.url("/").toString())
+                    .runCommandWithInput(input, "--color=never", "apps", "delete", "--verbose", "app-id1")
+
+            assertThat result, resultMatches(1, allOf(
+                    containsString("Deactivate and delete application 'app-id1'? [y/N]")),
+                    null)
+
+            verify(mockWebServer.takeRequest(), "GET", "/api/v1/apps/app-id1")
+            assertThat mockWebServer.requestCount, equalTo(1)
+        }
+    }
+
+    @Test
+    void nonInteractiveDeleteApp() {
+        MockWebServer mockWebServer = createMockServer()
+        List<MockResponse> responses = [
+                jsonRequest('{"id": "app-id1", "status": "ACTIVE"}')
+        ]
+
+        mockWebServer.with {
+            responses.forEach { mockWebServer.enqueue(it) }
+
+            List<String> input = []
+
+            def result = new CommandRunner()
+                    .withSdkConfig(mockWebServer.url("/").toString())
+                    .runCommandWithInput(input, "--color=never", "apps", "delete", "--batch", "app-id1")
+
+            assertThat result, resultMatches(1, allOf(
+                    containsString("Application 'app-id1' has not been deactivated, use '--force' to delete it"),
+                    not(containsString("Deactivate and delete application 'app-id1'? [y/N]"))),
+                    null)
+
+            verify(mockWebServer.takeRequest(), "GET", "/api/v1/apps/app-id1")
+            assertThat mockWebServer.requestCount, equalTo(1)
+        }
+    }
+
+    @Test
+    void deleteMultipleFirstFails() {
+        MockWebServer mockWebServer = createMockServer()
+        List<MockResponse> responses = [
+                jsonRequest('{"id": "app-id1", "status": "ACTIVE"}'),
+                new MockResponse().setResponseCode(400),
+                jsonRequest('{"id": "app-id2", "status": "ACTIVE"}'),
+                new MockResponse().setResponseCode(204),
+                new MockResponse().setResponseCode(204)
+        ]
+
+        mockWebServer.with {
+            responses.forEach { mockWebServer.enqueue(it) }
+
+            List<String> input = [
+                    "y",
+                    "y",
+            ]
+
+            def result = new CommandRunner()
+                    .withSdkConfig(mockWebServer.url("/").toString())
+                    .runCommandWithInput(input, "--color=never", "apps", "delete", "--verbose", "app-id1", "app-id2")
+
+            assertThat result, resultMatches(1, allOf(
+                    containsString("Deactivate and delete application 'app-id1'? [y/N]"),
+                    containsString("Failed to delete application: 'app-id1'"),
+                    containsString("Deactivate and delete application 'app-id2'? [y/N]"),
+                    containsString("Application 'app-id2' has been deleted")),
+                    null)
+
+            verify(mockWebServer.takeRequest(), "GET", "/api/v1/apps/app-id1")
+            verify(mockWebServer.takeRequest(), "POST", "/api/v1/apps/app-id1/lifecycle/deactivate")
+            verify(mockWebServer.takeRequest(), "GET", "/api/v1/apps/app-id2")
+            verify(mockWebServer.takeRequest(), "POST", "/api/v1/apps/app-id2/lifecycle/deactivate")
+            verify(mockWebServer.takeRequest(), "DELETE", "/api/v1/apps/app-id2")
+            assertThat mockWebServer.requestCount, equalTo(5)
         }
     }
 }

--- a/integration-tests/src/test/groovy/com/okta/cli/test/CommandRunner.groovy
+++ b/integration-tests/src/test/groovy/com/okta/cli/test/CommandRunner.groovy
@@ -73,6 +73,7 @@ class CommandRunner {
             : runProcess([] as String[], args, input)
     }
 
+    // TODO: this only works some time, consider removing this
     static boolean isIde() {
         return false && System.getProperty("java.class.path").contains("idea_rt.jar") && Classes.isAvailable("com.okta.cli.OktaCli")
     }

--- a/integration-tests/src/test/groovy/com/okta/cli/test/MockWebSupport.groovy
+++ b/integration-tests/src/test/groovy/com/okta/cli/test/MockWebSupport.groovy
@@ -18,6 +18,11 @@ package com.okta.cli.test
 import groovy.json.JsonOutput
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.containsString
+import static org.hamcrest.Matchers.equalTo
 
 trait MockWebSupport {
 
@@ -55,4 +60,10 @@ trait MockWebSupport {
     String url(MockWebServer server, String path) {
         return "http://localhost:${server.port}${path}"
     }
+
+    static void verify(RecordedRequest request, String method, String relativeUri) {
+        assertThat request.requestUrl.toString(), containsString(relativeUri)
+        assertThat request.method, equalTo(method)
+    }
+
 }

--- a/integration-tests/src/test/groovy/com/okta/cli/test/MockWebSupport.groovy
+++ b/integration-tests/src/test/groovy/com/okta/cli/test/MockWebSupport.groovy
@@ -21,7 +21,6 @@ import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
 
 import static org.hamcrest.MatcherAssert.assertThat
-import static org.hamcrest.Matchers.containsString
 import static org.hamcrest.Matchers.equalTo
 
 trait MockWebSupport {
@@ -61,8 +60,9 @@ trait MockWebSupport {
         return "http://localhost:${server.port}${path}"
     }
 
-    static void verify(RecordedRequest request, String method, String relativeUri) {
-        assertThat request.requestUrl.toString(), containsString(relativeUri)
+    void verify(RecordedRequest request, String method, String relativeUri, String query = null) {
+        assertThat request.requestUrl.uri().getPath(), equalTo(relativeUri)
+        assertThat request.requestUrl.uri().getQuery(), equalTo(query)
         assertThat request.method, equalTo(method)
     }
 


### PR DESCRIPTION
First pass at adding an application delete command

**NOTE:** Currently this command WILL also deactivate the application.

TODO:
- [x] Add Tests!
- [x] Figout how to deal with [de]activation.  These could likely be separate commands `okta apps deactivate`/`okta apps activate`

Usage:
```txt
Usage: okta apps delete [-fhV] [--batch] [--verbose] <appIds>...
Deletes an Okta app
      <appIds>...       List of application IDs to be deleted
      --batch           Batch mode, will not prompt for user input
  -f, --force           Deactivate and delete applications
  -h, --help            Show this help message and exit.
  -V, --version         Print version information and exit.
      --verbose         Verbose logging
```

Example:
```txt
okta apps delete -f my-app-id
```

or without the `-f` the user would be prompted:

```txt
Deactivate and delete application '0oaqkajn1qnUlRYQ30h7'? [y/N]y
Application '0oaqkajn1qnUlRYQ30h7' has been deleted
```