### PR TITLE
Fix NPE when reusing an application name

### DIFF
--- a/common/src/main/java/com/okta/cli/common/config/PropertiesFilePropertiesSource.java
+++ b/common/src/main/java/com/okta/cli/common/config/PropertiesFilePropertiesSource.java
@@ -39,11 +39,16 @@ public class PropertiesFilePropertiesSource extends WrappedMutablePropertiesSour
     }
 
     @Override
-    public void addProperties(Map<String, String> properties) throws IOException {
+    public void addProperties(Map<String, String> newProperties) throws IOException {
 
         Properties existingProps = new Properties();
         existingProps.putAll(getProperties());
-        existingProps.putAll(properties);
+
+        // Java Properties cannot handle null values (or keys) so filter them out
+        newProperties.entrySet().stream()
+                .filter(entry -> entry.getKey() != null)
+                .filter(entry -> entry.getValue() != null)
+                .forEach(entry -> existingProps.put(entry.getKey(), entry.getValue()));
 
         try (Writer writer = fileWriter(propertiesFile)) {
             existingProps.store(writer, null);

--- a/common/src/test/groovy/com/okta/cli/common/config/PropertiesFilePropertiesSourceTest.groovy
+++ b/common/src/test/groovy/com/okta/cli/common/config/PropertiesFilePropertiesSourceTest.groovy
@@ -81,6 +81,33 @@ class PropertiesFilePropertiesSourceTest {
         MatcherAssert.assertThat result, is("expected-value")
     }
 
+    @Test
+    void addPropertiesWithNull() {
+        File configFile = writeFile([
+                "spring.foo": "bar",
+                "spring.fooBar": "expected-value",
+                "spring.numbers.one": "1",
+                "spring.numbers.two": "two"],
+                "addPropertiesWithNull")
+
+        Map<String, String> newProps = [
+                "spring.foo": "bar-new",
+                "null-value": null,
+                "a-new-key": "a-new-value"
+        ]
+
+        Map<String, String> expectedMergedResult = [
+                "spring.foo": "bar-new",
+                "spring.fooBar": "expected-value",
+                "spring.numbers.one": "1",
+                "spring.numbers.two": "two",
+                "a-new-key": "a-new-value"
+        ]
+
+        new PropertiesFilePropertiesSource(configFile).addProperties(newProps)
+        assertThat readFromFile(configFile), is(expectedMergedResult)
+    }
+
     static File writeFile(Map data, String testName) {
         File tempFile = File.createTempFile(testName, "test.properties")
         tempFile.withWriter {


### PR DESCRIPTION
The root cause of this is a limitation in the Java Properties file handling of null value properties, those are explicitly excluded now
This is an edge case, but it could come up in _valid_ use cases when a web app is switched to use PKCE (without a secret)

Fixes: #56