### PR TITLE
Quarkus OIDC Support

### DIFF
--- a/cli/src/main/java/com/okta/cli/commands/apps/AppsCreate.java
+++ b/cli/src/main/java/com/okta/cli/commands/apps/AppsCreate.java
@@ -24,6 +24,7 @@ import com.okta.cli.common.URIs;
 import com.okta.cli.common.config.MapPropertySource;
 import com.okta.cli.common.config.MutablePropertySource;
 import com.okta.cli.common.model.AuthorizationServer;
+import com.okta.cli.common.model.OidcProperties;
 import com.okta.cli.common.service.ClientConfigurationException;
 import com.okta.cli.common.service.DefaultSdkConfigurationService;
 import com.okta.cli.common.service.DefaultSetupService;
@@ -100,8 +101,8 @@ public class AppsCreate extends BaseCommand {
         WebAppTemplate appTemplate = prompter.promptIfEmpty(webAppTemplate, "Type of Application", Arrays.asList(WebAppTemplate.values()), WebAppTemplate.GENERIC);
 
         List<String> redirectUris = getRedirectUris(Map.of("Spring Security", "http://localhost:8080/login/oauth2/code/okta",
-                                                   "Quarkus OIDC", "http://localhost:8080/",
-                                                   "JHipster", "http://localhost:8080/login/oauth2/code/oidc"),
+                                                    "Quarkus OIDC", "http://localhost:8080/",
+                                                    "JHipster", "http://localhost:8080/login/oauth2/code/oidc"),
                                             appTemplate.getDefaultRedirectUri());
         List<String> postLogoutRedirectUris = getPostLogoutRedirectUris(redirectUris);
         Client client = Clients.builder().build();
@@ -131,7 +132,7 @@ public class AppsCreate extends BaseCommand {
         AuthorizationServer issuer = getIssuer(client);
 
         MutablePropertySource propertySource = new MapPropertySource();
-        new DefaultSetupService(null).createOidcApplication(propertySource, appName, baseUrl, null, Collections.emptySet(), issuer.getIssuer(), issuer.getId(), getEnvironment().isInteractive(), OpenIdConnectApplicationType.NATIVE, redirectUris, postLogoutRedirectUris);
+        new DefaultSetupService(OidcProperties.oktaEnv()).createOidcApplication(propertySource, appName, baseUrl, null, Collections.emptySet(), issuer.getIssuer(), issuer.getId(), getEnvironment().isInteractive(), OpenIdConnectApplicationType.NATIVE, redirectUris, postLogoutRedirectUris);
 
         out.writeLine("Okta application configuration: ");
         propertySource.getProperties().forEach((key, value) -> {
@@ -174,7 +175,7 @@ public class AppsCreate extends BaseCommand {
         List<String> trustedOrigins = redirectUris.stream().map(URIs::baseUrlOf).collect(Collectors.toList());
 
         MutablePropertySource propertySource = new MapPropertySource();
-        new DefaultSetupService(null).createOidcApplication(propertySource, appName, baseUrl, null, Collections.emptySet(), authorizationServer.getIssuer(), authorizationServer.getId(), getEnvironment().isInteractive(), OpenIdConnectApplicationType.BROWSER, redirectUris, postLogoutRedirectUris, trustedOrigins);
+        new DefaultSetupService(OidcProperties.oktaEnv()).createOidcApplication(propertySource, appName, baseUrl, null, Collections.emptySet(), authorizationServer.getIssuer(), authorizationServer.getId(), getEnvironment().isInteractive(), OpenIdConnectApplicationType.BROWSER, redirectUris, postLogoutRedirectUris, trustedOrigins);
 
         out.writeLine("Okta application configuration: ");
         out.bold("Issuer:    ");
@@ -247,7 +248,7 @@ public class AppsCreate extends BaseCommand {
         // web
         OKTA_SPRING_BOOT("okta-spring-boot", AppType.WEB, WebAppTemplate.OKTA_SPRING_BOOT),
         SPRING_BOOT("spring-boot", AppType.WEB, WebAppTemplate.SPRING_BOOT),
-        Quarkus("quarkus", AppType.WEB, WebAppTemplate.QUARKUS),
+        QUARKUS("quarkus", AppType.WEB, WebAppTemplate.QUARKUS),
         JHIPSTER("jhipster", AppType.WEB, WebAppTemplate.JHIPSTER),
         GENERIC_WEB("web", AppType.WEB, WebAppTemplate.GENERIC),
         // service

--- a/cli/src/main/java/com/okta/cli/commands/apps/AppsCreate.java
+++ b/cli/src/main/java/com/okta/cli/commands/apps/AppsCreate.java
@@ -100,6 +100,7 @@ public class AppsCreate extends BaseCommand {
         WebAppTemplate appTemplate = prompter.promptIfEmpty(webAppTemplate, "Type of Application", Arrays.asList(WebAppTemplate.values()), WebAppTemplate.GENERIC);
 
         List<String> redirectUris = getRedirectUris(Map.of("Spring Security", "http://localhost:8080/login/oauth2/code/okta",
+                                                   "Quarkus OIDC", "http://localhost:8080/",
                                                    "JHipster", "http://localhost:8080/login/oauth2/code/oidc"),
                                             appTemplate.getDefaultRedirectUri());
         List<String> postLogoutRedirectUris = getPostLogoutRedirectUris(redirectUris);
@@ -110,7 +111,7 @@ public class AppsCreate extends BaseCommand {
         Set<String> groupsToCreate = appTemplate.getGroupsToCreate();
 
         MutablePropertySource propertySource = appCreationMixin.getPropertySource(appTemplate.getDefaultConfigFileName());
-        new DefaultSetupService(appTemplate.getSpringPropertyKey()).createOidcApplication(propertySource, appName, baseUrl, groupClaimName, groupsToCreate, issuer.getIssuer(), issuer.getId(), true, OpenIdConnectApplicationType.WEB, redirectUris, postLogoutRedirectUris);
+        new DefaultSetupService(appTemplate.getOidcProperties()).createOidcApplication(propertySource, appName, baseUrl, groupClaimName, groupsToCreate, issuer.getIssuer(), issuer.getId(), true, OpenIdConnectApplicationType.WEB, redirectUris, postLogoutRedirectUris);
 
         out.writeLine("Okta application configuration has been written to: " + propertySource.getName());
 
@@ -154,7 +155,7 @@ public class AppsCreate extends BaseCommand {
         AuthorizationServer issuer = getIssuer(client);
 
         MutablePropertySource propertySource = appCreationMixin.getPropertySource(appTemplate.getDefaultConfigFileName());
-        new DefaultSetupService(appTemplate.getSpringPropertyKey()).createOidcApplication(propertySource, appName, baseUrl, null, Collections.emptySet(), issuer.getIssuer(), issuer.getId(), getEnvironment().isInteractive(), OpenIdConnectApplicationType.SERVICE);
+        new DefaultSetupService(appTemplate.getOidcProperties()).createOidcApplication(propertySource, appName, baseUrl, null, Collections.emptySet(), issuer.getIssuer(), issuer.getId(), getEnvironment().isInteractive(), OpenIdConnectApplicationType.SERVICE);
 
         out.writeLine("Okta application configuration has been written to: " + propertySource.getName());
 
@@ -246,6 +247,7 @@ public class AppsCreate extends BaseCommand {
         // web
         OKTA_SPRING_BOOT("okta-spring-boot", AppType.WEB, WebAppTemplate.OKTA_SPRING_BOOT),
         SPRING_BOOT("spring-boot", AppType.WEB, WebAppTemplate.SPRING_BOOT),
+        Quarkus("quarkus", AppType.WEB, WebAppTemplate.QUARKUS),
         JHIPSTER("jhipster", AppType.WEB, WebAppTemplate.JHIPSTER),
         GENERIC_WEB("web", AppType.WEB, WebAppTemplate.GENERIC),
         // service

--- a/cli/src/main/java/com/okta/cli/commands/apps/templates/ServiceAppTemplate.java
+++ b/cli/src/main/java/com/okta/cli/commands/apps/templates/ServiceAppTemplate.java
@@ -15,6 +15,7 @@
  */
 package com.okta.cli.commands.apps.templates;
 
+import com.okta.cli.common.model.OidcProperties;
 import com.okta.cli.console.PromptOption;
 
 import java.util.Arrays;
@@ -24,24 +25,25 @@ import java.util.stream.Collectors;
 public enum ServiceAppTemplate implements PromptOption<ServiceAppTemplate> {
 
     OKTA_SPRING_BOOT("Okta Spring Boot Starter", null,  "src/main/resources/application.properties"),
-    SPRING_BOOT("Spring Boot", "okta",  "src/main/resources/application.properties"),
-    JHIPSTER("JHipster", "oidc", ".okta.env"),
+    SPRING_BOOT("Spring Boot", OidcProperties.spring("okta"),  "src/main/resources/application.properties"),
+    JHIPSTER("JHipster", OidcProperties.oktaEnv(), ".okta.env"),
+    QUARKUS("Quarkus", OidcProperties.quarkus(), "src/main/resources/application.properties"),
     GENERIC("Other", null, ".okta.env");
 
     private static final Map<String, ServiceAppTemplate> nameToTemplateMap = Arrays.stream(values()).collect(Collectors.toMap(it -> it.friendlyName, it -> it));
 
     private final String friendlyName;
-    private final String springPropertyKey;
+    private final OidcProperties oidcProperties;
     private final String defaultConfigFileName;
 
-    ServiceAppTemplate(String friendlyName, String springPropertyKey, String defaultConfigFileName) {
+    ServiceAppTemplate(String friendlyName, OidcProperties oidcProperties, String defaultConfigFileName) {
         this.friendlyName = friendlyName;
-        this.springPropertyKey = springPropertyKey;
+        this.oidcProperties = oidcProperties;
         this.defaultConfigFileName = defaultConfigFileName;
     }
 
-    public String getSpringPropertyKey() {
-        return springPropertyKey;
+    public OidcProperties getOidcProperties() {
+        return oidcProperties;
     }
 
     public String getDefaultConfigFileName() {

--- a/cli/src/main/java/com/okta/cli/commands/apps/templates/ServiceAppTemplate.java
+++ b/cli/src/main/java/com/okta/cli/commands/apps/templates/ServiceAppTemplate.java
@@ -24,11 +24,11 @@ import java.util.stream.Collectors;
 
 public enum ServiceAppTemplate implements PromptOption<ServiceAppTemplate> {
 
-    OKTA_SPRING_BOOT("Okta Spring Boot Starter", null,  "src/main/resources/application.properties"),
+    OKTA_SPRING_BOOT("Okta Spring Boot Starter", OidcProperties.spring("okta"),  "src/main/resources/application.properties"),
     SPRING_BOOT("Spring Boot", OidcProperties.spring("okta"),  "src/main/resources/application.properties"),
     JHIPSTER("JHipster", OidcProperties.oktaEnv(), ".okta.env"),
     QUARKUS("Quarkus", OidcProperties.quarkus(), "src/main/resources/application.properties"),
-    GENERIC("Other", null, ".okta.env");
+    GENERIC("Other", OidcProperties.oktaEnv(), ".okta.env");
 
     private static final Map<String, ServiceAppTemplate> nameToTemplateMap = Arrays.stream(values()).collect(Collectors.toMap(it -> it.friendlyName, it -> it));
 

--- a/cli/src/main/java/com/okta/cli/commands/apps/templates/WebAppTemplate.java
+++ b/cli/src/main/java/com/okta/cli/commands/apps/templates/WebAppTemplate.java
@@ -31,7 +31,7 @@ public enum WebAppTemplate implements PromptOption<WebAppTemplate> {
     SPRING_BOOT("Spring Boot", OidcProperties.spring("okta"), "src/main/resources/application.properties", "http://localhost:8080/login/oauth2/code/okta", null),
     JHIPSTER("JHipster", OidcProperties.oktaEnv(), ".okta.env", "http://localhost:8080/login/oauth2/code/oidc", "groups", Set.of("ROLE_USER", "ROLE_ADMIN")),
     QUARKUS("Quarkus", OidcProperties.quarkus(OpenIdConnectApplicationType.WEB), "src/main/resources/application.properties", "http://localhost:8080/", null),
-    GENERIC("Other", null, ".okta.env", "http://localhost:8080/callback", null);
+    GENERIC("Other", OidcProperties.oktaEnv(), ".okta.env", "http://localhost:8080/callback", null);
 
     private static final Map<String, WebAppTemplate> nameToTemplateMap = Arrays.stream(values()).collect(Collectors.toMap(it -> it.friendlyName, it -> it));
 

--- a/cli/src/main/java/com/okta/cli/commands/apps/templates/WebAppTemplate.java
+++ b/cli/src/main/java/com/okta/cli/commands/apps/templates/WebAppTemplate.java
@@ -15,7 +15,9 @@
  */
 package com.okta.cli.commands.apps.templates;
 
+import com.okta.cli.common.model.OidcProperties;
 import com.okta.cli.console.PromptOption;
+import com.okta.sdk.resource.application.OpenIdConnectApplicationType;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -25,35 +27,36 @@ import java.util.stream.Collectors;
 
 public enum WebAppTemplate implements PromptOption<WebAppTemplate> {
 
-    OKTA_SPRING_BOOT("Okta Spring Boot Starter", null, "src/main/resources/application.properties", "http://localhost:8080/login/oauth2/code/okta", null),
-    SPRING_BOOT("Spring Boot", "okta", "src/main/resources/application.properties", "http://localhost:8080/login/oauth2/code/okta", null),
-    JHIPSTER("JHipster", "oidc", ".okta.env", "http://localhost:8080/login/oauth2/code/oidc", "groups", Set.of("ROLE_USER", "ROLE_ADMIN")),
+    OKTA_SPRING_BOOT("Okta Spring Boot Starter", OidcProperties.spring("okta"), "src/main/resources/application.properties", "http://localhost:8080/login/oauth2/code/okta", null),
+    SPRING_BOOT("Spring Boot", OidcProperties.spring("okta"), "src/main/resources/application.properties", "http://localhost:8080/login/oauth2/code/okta", null),
+    JHIPSTER("JHipster", OidcProperties.oktaEnv(), ".okta.env", "http://localhost:8080/login/oauth2/code/oidc", "groups", Set.of("ROLE_USER", "ROLE_ADMIN")),
+    QUARKUS("Quarkus", OidcProperties.quarkus(OpenIdConnectApplicationType.WEB), "src/main/resources/application.properties", "http://localhost:8080/", null),
     GENERIC("Other", null, ".okta.env", "http://localhost:8080/callback", null);
 
     private static final Map<String, WebAppTemplate> nameToTemplateMap = Arrays.stream(values()).collect(Collectors.toMap(it -> it.friendlyName, it -> it));
 
     private final String friendlyName;
-    private final String springPropertyKey;
+    private final OidcProperties oidcProperties;
     private final String defaultConfigFileName;
     private final String defaultRedirectUri;
     private final String groupsClaim;
     public final Set<String> groupsToCreate;
 
-    WebAppTemplate(String friendlyName, String springPropertyKey, String defaultConfigFileName, String defaultRedirectUri, String groupsClaim, Set<String> groupsToCreate) {
+    WebAppTemplate(String friendlyName, OidcProperties oidcProperties, String defaultConfigFileName, String defaultRedirectUri, String groupsClaim, Set<String> groupsToCreate) {
         this.friendlyName = friendlyName;
-        this.springPropertyKey = springPropertyKey;
+        this.oidcProperties = oidcProperties;
         this.defaultConfigFileName = defaultConfigFileName;
         this.defaultRedirectUri = defaultRedirectUri;
         this.groupsClaim = groupsClaim;
         this.groupsToCreate = Collections.unmodifiableSet(groupsToCreate);
     }
 
-    WebAppTemplate(String friendlyName, String springPropertyKey, String defaultConfigFileName, String defaultRedirectUri, String groupsClaim) {
-        this(friendlyName, springPropertyKey, defaultConfigFileName, defaultRedirectUri, groupsClaim, Collections.emptySet());
+    WebAppTemplate(String friendlyName, OidcProperties oidcProperties, String defaultConfigFileName, String defaultRedirectUri, String groupsClaim) {
+        this(friendlyName, oidcProperties, defaultConfigFileName, defaultRedirectUri, groupsClaim, Collections.emptySet());
     }
 
-    public String getSpringPropertyKey() {
-        return springPropertyKey;
+    public OidcProperties getOidcProperties() {
+        return oidcProperties;
     }
 
     public String getDefaultConfigFileName() {

--- a/common/src/main/java/com/okta/cli/common/model/OidcProperties.java
+++ b/common/src/main/java/com/okta/cli/common/model/OidcProperties.java
@@ -1,6 +1,20 @@
+/*
+ * Copyright 2020-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.okta.cli.common.model;
 
-import com.okta.cli.common.URIs;
 import com.okta.sdk.resource.application.OpenIdConnectApplicationType;
 
 import java.net.URI;
@@ -42,7 +56,6 @@ public abstract class OidcProperties {
     String clientId;
     String clientSecret;
     List<String> redirectUris;
-    List<String> postLogoutRedirectUris;
 
     OidcProperties(String issuerUriPropertyName, String clientIdPropertyName, String clientSecretPropertyName) {
         this.issuerUriPropertyName = issuerUriPropertyName;
@@ -66,19 +79,13 @@ public abstract class OidcProperties {
         this.redirectUris = redirectUris;
     }
 
-    public void setPostLogoutRedirectUris(List<String> postLogoutRedirectUris) {
-        this.postLogoutRedirectUris = postLogoutRedirectUris;
-    }
-
     abstract Map<String, String> getOidcClientProperties();
 
     public Map<String, String> getProperties() {
-        Map<String, String> properties = new HashMap<>(Map.of(
-                issuerUriPropertyName, issuerUri,
-                clientIdPropertyName, clientId,
-                clientSecretPropertyName, clientSecret
-        ));
-
+        Map<String, String> properties = new HashMap<>();
+        properties.put(issuerUriPropertyName, issuerUri);
+        properties.put(clientIdPropertyName, clientId);
+        properties.put(clientSecretPropertyName, clientSecret);
         properties.putAll(getOidcClientProperties());
 
         return properties;
@@ -132,7 +139,10 @@ public abstract class OidcProperties {
 
         @Override
         Map<String, String> getOidcClientProperties() {
-            String redirectUri = redirectUris.get(0);
+            String redirectUri = "/";
+            if (redirectUris != null && !redirectUris.isEmpty()) {
+                redirectUri = redirectUris.get(0);
+            }
 
             return Map.of(
                     "quarkus.oidc.application-type", applicationType,

--- a/common/src/main/java/com/okta/cli/common/model/OidcProperties.java
+++ b/common/src/main/java/com/okta/cli/common/model/OidcProperties.java
@@ -1,0 +1,144 @@
+package com.okta.cli.common.model;
+
+import com.okta.cli.common.URIs;
+import com.okta.sdk.resource.application.OpenIdConnectApplicationType;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.lang.String.format;
+
+public abstract class OidcProperties {
+
+
+    public static OktaEnvOidcProperties oktaEnv() {
+        return new OktaEnvOidcProperties();
+    }
+
+    public static SpringOidcProperties spring() {
+        return spring("oidc");
+    }
+
+    public static SpringOidcProperties spring(String tenantId) {
+        return new SpringOidcProperties(tenantId);
+    }
+
+    public static QuarkusOidcProperties quarkus() {
+        return quarkus(OpenIdConnectApplicationType.SERVICE);
+    }
+
+    public static QuarkusOidcProperties quarkus(OpenIdConnectApplicationType applicationType) {
+        return new QuarkusOidcProperties(applicationType);
+    }
+
+    public final String issuerUriPropertyName;
+    public final String clientIdPropertyName;
+    public final String clientSecretPropertyName;
+
+    String issuerUri;
+    String clientId;
+    String clientSecret;
+    List<String> redirectUris;
+    List<String> postLogoutRedirectUris;
+
+    OidcProperties(String issuerUriPropertyName, String clientIdPropertyName, String clientSecretPropertyName) {
+        this.issuerUriPropertyName = issuerUriPropertyName;
+        this.clientIdPropertyName = clientIdPropertyName;
+        this.clientSecretPropertyName = clientSecretPropertyName;
+    }
+
+    public void setIssuerUri(String issuerUri) {
+        this.issuerUri = issuerUri;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public void setClientSecret(String clientSecret) {
+        this.clientSecret = clientSecret;
+    }
+
+    public void setRedirectUris(List<String> redirectUris) {
+        this.redirectUris = redirectUris;
+    }
+
+    public void setPostLogoutRedirectUris(List<String> postLogoutRedirectUris) {
+        this.postLogoutRedirectUris = postLogoutRedirectUris;
+    }
+
+    abstract Map<String, String> getOidcClientProperties();
+
+    public Map<String, String> getProperties() {
+        Map<String, String> properties = new HashMap<>(Map.of(
+                issuerUriPropertyName, issuerUri,
+                clientIdPropertyName, clientId,
+                clientSecretPropertyName, clientSecret
+        ));
+
+        properties.putAll(getOidcClientProperties());
+
+        return properties;
+    }
+
+    public static class SpringOidcProperties extends OidcProperties {
+        public SpringOidcProperties(String tenantId) {
+            super(
+                    format("spring.security.oauth2.client.provider.%s.issuer-uri", tenantId),
+                    format("spring.security.oauth2.client.registration.%s.client-id", tenantId),
+                    format("spring.security.oauth2.client.registration.%s.client-secret", tenantId)
+            );
+        }
+
+        @Override
+        Map<String, String> getOidcClientProperties() {
+            return Collections.emptyMap();
+        }
+    }
+
+    public static class OktaEnvOidcProperties extends OidcProperties {
+        public OktaEnvOidcProperties() {
+            super(
+                    "okta.oauth2.issuer",
+                    "okta.oauth2.client-id",
+                    "okta.oauth2.client-secret"
+            );
+        }
+
+        @Override
+        Map<String, String> getOidcClientProperties() {
+            return Collections.emptyMap();
+        }
+    }
+
+    public static class QuarkusOidcProperties extends OidcProperties {
+        public final String applicationType;
+
+        public QuarkusOidcProperties(OpenIdConnectApplicationType applicationType) {
+            super(
+                    "quarkus.oidc.auth-server-url",
+                    "quarkus.oidc.client-id",
+                    "quarkus.oidc.credentials.secret"
+            );
+            if (applicationType == OpenIdConnectApplicationType.WEB) {
+                this.applicationType = "web-app";
+            } else {
+                this.applicationType = "service";
+            }
+        }
+
+        @Override
+        Map<String, String> getOidcClientProperties() {
+            String redirectUri = redirectUris.get(0);
+
+            return Map.of(
+                    "quarkus.oidc.application-type", applicationType,
+                    "quarkus.oidc.authentication.redirect-path", URI.create(redirectUri).getPath()
+            );
+        }
+    }
+
+}

--- a/common/src/main/java/com/okta/cli/common/service/DefaultSetupService.java
+++ b/common/src/main/java/com/okta/cli/common/service/DefaultSetupService.java
@@ -18,6 +18,7 @@ package com.okta.cli.common.service;
 import com.okta.cli.common.FactorVerificationException;
 import com.okta.cli.common.RestException;
 import com.okta.cli.common.config.MutablePropertySource;
+import com.okta.cli.common.model.OidcProperties;
 import com.okta.cli.common.model.OrganizationRequest;
 import com.okta.cli.common.model.OrganizationResponse;
 import com.okta.cli.common.model.RegistrationQuestions;
@@ -46,10 +47,7 @@ import java.nio.file.StandardCopyOption;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -63,27 +61,27 @@ public class DefaultSetupService implements SetupService {
 
     private final AuthorizationServerService authorizationServerService;
 
-    private final String springPropertyKey;
+    private final OidcProperties oidcProperties;
 
 
-    public DefaultSetupService(String springPropertyKey) {
+    public DefaultSetupService(OidcProperties oidcProperties) {
         this(new DefaultSdkConfigurationService(),
                 new DefaultOktaOrganizationCreator(),
                 new DefaultOidcAppCreator(),
                 new DefaultAuthorizationServerService(),
-                springPropertyKey);
+                oidcProperties);
     }
 
     public DefaultSetupService(SdkConfigurationService sdkConfigurationService,
                                OktaOrganizationCreator organizationCreator,
                                OidcAppCreator oidcAppCreator, 
                                AuthorizationServerService authorizationServerService,
-                               String springPropertyKey) {
+                               OidcProperties oidcProperties) {
         this.sdkConfigurationService = sdkConfigurationService;
         this.organizationCreator = organizationCreator;
         this.oidcAppCreator = oidcAppCreator;
         this.authorizationServerService = authorizationServerService;
-        this.springPropertyKey = springPropertyKey;
+        this.oidcProperties = oidcProperties;
     }
 
     @Override
@@ -177,7 +175,7 @@ public class DefaultSetupService implements SetupService {
                                       List<String> trustedOrigins) throws IOException {
 
         // Create new Application
-        String clientId = propertySource.getProperty(getClientIdPropertyName());
+        String clientId = propertySource.getProperty(oidcProperties.clientIdPropertyName);
 
         try (ProgressBar progressBar = ProgressBar.create(interactive)) {
             if (!ConfigurationValidator.validateClientId(clientId).isValid()) {
@@ -209,12 +207,13 @@ public class DefaultSetupService implements SetupService {
                     issuerUri = orgUrl + "/oauth2/" + authorizationServerId;
                 }
 
-                Map<String, String> newProps = new HashMap<>();
-                newProps.put(getIssuerUriPropertyName(), issuerUri);
-                newProps.put(getClientIdPropertyName(), clientCredsResponse.getString("client_id"));
-                newProps.put(getClientSecretPropertyName(), clientCredsResponse.getString("client_secret"));
+                oidcProperties.setIssuerUri(issuerUri);
+                oidcProperties.setClientId(clientCredsResponse.getString("client_id"));
+                oidcProperties.setClientSecret(clientCredsResponse.getString("client_secret"));
+                oidcProperties.setRedirectUris(redirectUris);
+                oidcProperties.setPostLogoutRedirectUris(postLogoutRedirectUris);
 
-                propertySource.addProperties(newProps);
+                propertySource.addProperties(oidcProperties.getProperties());
 
                 progressBar.info("Created OIDC application, client-id: " + clientCredsResponse.getString("client_id"));
 
@@ -300,23 +299,5 @@ public class DefaultSetupService implements SetupService {
                 );
             });
         }
-    }
-
-    private String getIssuerUriPropertyName() {
-        return Optional.ofNullable(springPropertyKey)
-                .map(id -> "spring.security.oauth2.client.provider." + id + ".issuer-uri")
-                .orElse("okta.oauth2.issuer");
-    }
-
-    private String getClientIdPropertyName() {
-        return Optional.ofNullable(springPropertyKey)
-                .map(id -> "spring.security.oauth2.client.registration." + id + ".client-id")
-                .orElse("okta.oauth2.client-id");
-    }
-
-    private String getClientSecretPropertyName() {
-        return Optional.ofNullable(springPropertyKey)
-                .map(id -> "spring.security.oauth2.client.registration." + id + ".client-secret")
-                .orElse("okta.oauth2.client-secret");
     }
 }

--- a/common/src/main/java/com/okta/cli/common/service/DefaultSetupService.java
+++ b/common/src/main/java/com/okta/cli/common/service/DefaultSetupService.java
@@ -211,7 +211,6 @@ public class DefaultSetupService implements SetupService {
                 oidcProperties.setClientId(clientCredsResponse.getString("client_id"));
                 oidcProperties.setClientSecret(clientCredsResponse.getString("client_secret"));
                 oidcProperties.setRedirectUris(redirectUris);
-                oidcProperties.setPostLogoutRedirectUris(postLogoutRedirectUris);
 
                 propertySource.addProperties(oidcProperties.getProperties());
 

--- a/common/src/test/groovy/com/okta/cli/common/model/OidcPropertiesTest.groovy
+++ b/common/src/test/groovy/com/okta/cli/common/model/OidcPropertiesTest.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.okta.cli.common.model
 
 import org.testng.annotations.Test

--- a/common/src/test/groovy/com/okta/cli/common/model/OidcPropertiesTest.groovy
+++ b/common/src/test/groovy/com/okta/cli/common/model/OidcPropertiesTest.groovy
@@ -1,0 +1,53 @@
+package com.okta.cli.common.model
+
+import org.testng.annotations.Test
+
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.is
+
+class OidcPropertiesTest {
+
+    @Test
+    void propertyNameTest() {
+        def oidcProperties1 = OidcProperties.oktaEnv()
+        assertThat oidcProperties1.issuerUriPropertyName, is("okta.oauth2.issuer")
+        assertThat oidcProperties1.clientIdPropertyName, is("okta.oauth2.client-id")
+        assertThat oidcProperties1.clientSecretPropertyName , is("okta.oauth2.client-secret")
+
+        def oidcProperties2 = OidcProperties.spring("okta")
+        assertThat oidcProperties2.issuerUriPropertyName, is("spring.security.oauth2.client.provider.okta.issuer-uri")
+        assertThat oidcProperties2.clientIdPropertyName, is("spring.security.oauth2.client.registration.okta.client-id")
+        assertThat oidcProperties2.clientSecretPropertyName, is("spring.security.oauth2.client.registration.okta.client-secret")
+
+        def oidcProperties3 = OidcProperties.spring("oidc")
+        assertThat oidcProperties3.issuerUriPropertyName, is("spring.security.oauth2.client.provider.oidc.issuer-uri")
+        assertThat oidcProperties3.clientIdPropertyName, is("spring.security.oauth2.client.registration.oidc.client-id")
+        assertThat oidcProperties3.clientSecretPropertyName, is("spring.security.oauth2.client.registration.oidc.client-secret")
+
+        def oidcProperties4 = OidcProperties.quarkus()
+        assertThat oidcProperties4.issuerUriPropertyName, is("quarkus.oidc.auth-server-url")
+        assertThat oidcProperties4.clientIdPropertyName, is("quarkus.oidc.client-id")
+        assertThat oidcProperties4.clientSecretPropertyName, is("quarkus.oidc.credentials.secret")
+    }
+
+    @Test
+    void quarkusOidcProperties() {
+        def oidcProperties = OidcProperties.quarkus()
+        oidcProperties.setIssuerUri("http://example.org")
+        oidcProperties.setClientId("aClientId")
+        oidcProperties.setClientSecret("aClientSecret")
+
+        oidcProperties.setRedirectUris(List.of("http://localhost:8080/"))
+        def clientProperties1 = oidcProperties.getProperties()
+        assertThat clientProperties1.get("quarkus.oidc.authentication.redirect-path"), is("/")
+
+        oidcProperties.setRedirectUris(List.of("http://localhost:8080/web-app"))
+        def clientProperties2 = oidcProperties.getProperties()
+        assertThat clientProperties2.get("quarkus.oidc.authentication.redirect-path"), is("/web-app")
+
+        oidcProperties.setRedirectUris(List.of("http://localhost:8080/login/oauth2/code/oidc"))
+        def clientProperties3 = oidcProperties.getProperties()
+        assertThat clientProperties3.get("quarkus.oidc.authentication.redirect-path"), is("/login/oauth2/code/oidc")
+
+    }
+}

--- a/common/src/test/groovy/com/okta/cli/common/service/DefaultSetupServiceTest.groovy
+++ b/common/src/test/groovy/com/okta/cli/common/service/DefaultSetupServiceTest.groovy
@@ -18,6 +18,7 @@ package com.okta.cli.common.service
 import com.okta.cli.common.FactorVerificationException
 import com.okta.cli.common.config.MutablePropertySource
 import com.okta.cli.common.model.ErrorResponse
+import com.okta.cli.common.model.OidcProperties
 import com.okta.cli.common.model.OrganizationRequest
 import com.okta.cli.common.model.OrganizationResponse
 import com.okta.cli.common.model.RegistrationQuestions
@@ -279,24 +280,6 @@ class DefaultSetupServiceTest {
     }
 
     @Test
-    void propertyNameTest() {
-        def setupService1 = setupService()
-        assertThat setupService1.getIssuerUriPropertyName(), is("okta.oauth2.issuer")
-        assertThat setupService1.getClientIdPropertyName(), is("okta.oauth2.client-id")
-        assertThat setupService1.getClientSecretPropertyName(), is("okta.oauth2.client-secret")
-
-        def setupService2 = setupService("okta")
-        assertThat setupService2.getIssuerUriPropertyName(), is("spring.security.oauth2.client.provider.okta.issuer-uri")
-        assertThat setupService2.getClientIdPropertyName(), is("spring.security.oauth2.client.registration.okta.client-id")
-        assertThat setupService2.getClientSecretPropertyName(), is("spring.security.oauth2.client.registration.okta.client-secret")
-
-        def setupService3 = setupService("oidc")
-        assertThat setupService3.getIssuerUriPropertyName(), is("spring.security.oauth2.client.provider.oidc.issuer-uri")
-        assertThat setupService3.getClientIdPropertyName(), is("spring.security.oauth2.client.registration.oidc.client-id")
-        assertThat setupService3.getClientSecretPropertyName(), is("spring.security.oauth2.client.registration.oidc.client-secret")
-    }
-
-    @Test
     void configureTrustedOriginTest_null() {
 
         Client client = mock(Client)
@@ -413,14 +396,14 @@ class DefaultSetupServiceTest {
         verifyNoMoreInteractions(client)
     }
 
-    private static DefaultSetupService setupService(String springPropertyKey = null) {
+    private static DefaultSetupService setupService(OidcProperties oidcProperties = OidcProperties.oktaEnv()) {
         OktaOrganizationCreator organizationCreator = mock(OktaOrganizationCreator)
         SdkConfigurationService sdkConfigurationService = mock(SdkConfigurationService)
         OidcAppCreator oidcAppCreator = mock(OidcAppCreator)
         AuthorizationServerService authServerService = mock(AuthorizationServerService)
         when(sdkConfigurationService.loadUnvalidatedConfiguration()).thenReturn(new ClientConfiguration())
 
-        DefaultSetupService setupService = new DefaultSetupService(sdkConfigurationService, organizationCreator, oidcAppCreator, authServerService, springPropertyKey)
+        DefaultSetupService setupService = new DefaultSetupService(sdkConfigurationService, organizationCreator, oidcAppCreator, authServerService, oidcProperties)
 
         return setupService
     }


### PR DESCRIPTION
This PR aims to ease the Quarkus+Okta integration.
Here you have an example
```
Application name [sample-okta-quarkus]: 
Type of Application
(The Okta CLI only supports a subset of application types and properties):
> 1: Web
> 2: Single Page App
> 3: Native App (mobile)
> 4: Service (Machine-to-Machine)
Enter your choice [Web]: 1
Type of Application
> 1: Okta Spring Boot Starter
> 2: Spring Boot
> 3: JHipster
> 4: Quarkus
> 5: Other
Enter your choice [Other]: 4
Redirect URI
Common defaults:
 JHipster - http://localhost:8080/login/oauth2/code/oidc
 Spring Security - http://localhost:8080/login/oauth2/code/okta
 Quarkus OIDC - http://localhost:8080/
Enter your Redirect URI [http://localhost:8080/]: 
Enter your Post Logout Redirect URI [http://localhost:8080/]: 
Existing OIDC application detected for clientId: 0oa1l1yt0yLxNjkvo4x7, skipping new application creation

Okta application configuration has been written to: /Users/daniel/workspace/sample-okta-quarkus/src/main/resources/application.properties
```

And generates:
```
#Mon Dec 14 22:33:01 CET 2020
quarkus.oidc.client-id=0oa1l1yt0yLxNjkvo4x7
quarkus.oidc.authentication.redirect-path=/
quarkus.oidc.auth-server-url=https\://dev-956280.okta.com/oauth2/default
quarkus.oidc.credentials.secret={Secret}
quarkus.oidc.application-type=web-app
```

The challenging part has been generating the `quarkus.oidc.application-type` and `quarkus.oidc.authentication.redirect-path` properties on top of the usual OIDC properties.
As explained in [Okta's blog](https://developer.okta.com/blog/2020/04/08/kafka-streams) the `redirect-path` property is confusing. 
Without `redirect-path` set, the Quarkus OIDC client uses the current URI which would ends up with an error since the URI may not be registered in Okta... Sounds bad right?
To improve the overall experience, it's mandatory to provide a default configuration for this value.
