### PR TITLE
Add support for multiple redirect URIs in templates

### DIFF
--- a/cli/src/main/java/com/okta/cli/commands/apps/AppsCreate.java
+++ b/cli/src/main/java/com/okta/cli/commands/apps/AppsCreate.java
@@ -101,7 +101,7 @@ public class AppsCreate extends BaseCommand {
 
         List<String> redirectUris = getRedirectUris(Map.of("Spring Security", "http://localhost:8080/login/oauth2/code/okta",
                                                    "JHipster", "http://localhost:8080/login/oauth2/code/oidc"),
-                                            appTemplate.getDefaultRedirectUri());
+                                            appTemplate.getDefaultRedirectUris());
         List<String> postLogoutRedirectUris = getPostLogoutRedirectUris(redirectUris);
         Client client = Clients.builder().build();
         AuthorizationServer issuer = getIssuer(client);
@@ -202,29 +202,33 @@ public class AppsCreate extends BaseCommand {
         }
     }
 
-    private List<String> getRedirectUris(Map<String, String> commonExamples, String defaultRedirectUri) {
+    private List<String> getRedirectUris(Map<String, String> commonExamples, List<String> defaultRedirectUris) {
         Prompter prompter = getPrompter();
 
         StringBuilder redirectUriPrompt = new StringBuilder("Redirect URI\nCommon defaults:\n");
         commonExamples.forEach((key, value) -> {
-                redirectUriPrompt.append(" ").append(key).append(" - ").append(value).append("\n");
+            redirectUriPrompt.append(" ").append(key).append(" - ").append(value).append("\n");
         });
-        redirectUriPrompt.append("Enter your Redirect URI");
+        redirectUriPrompt.append("Enter your Redirect URI(s)");
 
-        String result = prompter.promptIfEmpty(appCreationMixin.redirectUri, redirectUriPrompt.toString(), defaultRedirectUri).trim();
+        String redirectUrisString = String.join(", ", defaultRedirectUris);
+        String result = prompter.promptIfEmpty(appCreationMixin.redirectUri, redirectUriPrompt.toString(), redirectUrisString).trim();
         return split(result);
+    }
+
+    private List<String> getRedirectUris(Map<String, String> commonExamples, String defaultRedirectUri) {
+        return getRedirectUris(commonExamples, Collections.singletonList(defaultRedirectUri));
     }
 
     private List<String> getPostLogoutRedirectUris(List<String> redirectUris) {
         Prompter prompter = getPrompter();
 
         Assert.notEmpty(redirectUris, "Redirect Uris cannot be empty");
-        String defaultPostLogoutUri = redirectUris.stream()
-                .findFirst()
+        String defaultPostLogoutUris = redirectUris.stream()
                 .map(URIs::baseUrlOf)
-                .get();
+                .collect(Collectors.joining(", "));
 
-        String result = prompter.promptIfEmpty(appCreationMixin.redirectUri, "Enter your Post Logout Redirect URI", defaultPostLogoutUri).trim();
+        String result = prompter.promptIfEmpty(appCreationMixin.redirectUri, "Enter your Post Logout Redirect URI(s)", defaultPostLogoutUris).trim();
         return split(result);
     }
 

--- a/cli/src/main/java/com/okta/cli/commands/apps/templates/WebAppTemplate.java
+++ b/cli/src/main/java/com/okta/cli/commands/apps/templates/WebAppTemplate.java
@@ -19,6 +19,7 @@ import com.okta.cli.console.PromptOption;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -27,7 +28,13 @@ public enum WebAppTemplate implements PromptOption<WebAppTemplate> {
 
     OKTA_SPRING_BOOT("Okta Spring Boot Starter", null, "src/main/resources/application.properties", "http://localhost:8080/login/oauth2/code/okta", null),
     SPRING_BOOT("Spring Boot", "okta", "src/main/resources/application.properties", "http://localhost:8080/login/oauth2/code/okta", null),
-    JHIPSTER("JHipster", "oidc", ".okta.env", "http://localhost:8080/login/oauth2/code/oidc", "groups", Set.of("ROLE_USER", "ROLE_ADMIN")),
+    JHIPSTER("JHipster",
+            "oidc",
+            ".okta.env",
+            List.of("http://localhost:8080/login/oauth2/code/oidc",
+                    "http://localhost:8761/login/oauth2/code/oidc"),
+            "groups",
+            Set.of("ROLE_USER", "ROLE_ADMIN")),
     GENERIC("Other", null, ".okta.env", "http://localhost:8080/callback", null);
 
     private static final Map<String, WebAppTemplate> nameToTemplateMap = Arrays.stream(values()).collect(Collectors.toMap(it -> it.friendlyName, it -> it));
@@ -35,15 +42,19 @@ public enum WebAppTemplate implements PromptOption<WebAppTemplate> {
     private final String friendlyName;
     private final String springPropertyKey;
     private final String defaultConfigFileName;
-    private final String defaultRedirectUri;
+    private final List<String> defaultRedirectUris;
     private final String groupsClaim;
     public final Set<String> groupsToCreate;
 
     WebAppTemplate(String friendlyName, String springPropertyKey, String defaultConfigFileName, String defaultRedirectUri, String groupsClaim, Set<String> groupsToCreate) {
+        this(friendlyName, springPropertyKey, defaultConfigFileName, Collections.singletonList(defaultRedirectUri), groupsClaim, groupsToCreate);
+    }
+
+    WebAppTemplate(String friendlyName, String springPropertyKey, String defaultConfigFileName, List<String> defaultRedirectUris, String groupsClaim, Set<String> groupsToCreate) {
         this.friendlyName = friendlyName;
         this.springPropertyKey = springPropertyKey;
         this.defaultConfigFileName = defaultConfigFileName;
-        this.defaultRedirectUri = defaultRedirectUri;
+        this.defaultRedirectUris = Collections.unmodifiableList(defaultRedirectUris);
         this.groupsClaim = groupsClaim;
         this.groupsToCreate = Collections.unmodifiableSet(groupsToCreate);
     }
@@ -60,8 +71,8 @@ public enum WebAppTemplate implements PromptOption<WebAppTemplate> {
         return defaultConfigFileName;
     }
 
-    public String getDefaultRedirectUri() {
-        return defaultRedirectUri;
+    public List<String> getDefaultRedirectUris() {
+        return defaultRedirectUris;
     }
 
     public String getGroupsClaim() {

--- a/integration-tests/src/test/groovy/com/okta/cli/test/AppsCreateIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/cli/test/AppsCreateIT.groovy
@@ -65,8 +65,8 @@ class AppsCreateIT implements MockWebSupport, CreateAppSupport {
 
 
             assertThat result, resultMatches(0, allOf(
-                                                            containsString("Enter your Redirect URI [http://localhost:8080/callback]:"),
-                                                            containsString("Enter your Post Logout Redirect URI [http://localhost:8080/]:"),
+                                                            containsString("Enter your Redirect URI(s) [http://localhost:8080/callback]:"),
+                                                            containsString("Enter your Post Logout Redirect URI(s) [http://localhost:8080/]:"),
                                                             containsString("Okta application configuration:"),
                                                             containsString("Client ID: test-id"),
                                                             containsString("Issuer:    ${url(mockWebServer,"/")}/oauth2/test-as"),
@@ -75,7 +75,7 @@ class AppsCreateIT implements MockWebSupport, CreateAppSupport {
 
             verify(mockWebServer.takeRequest(), "GET", "/api/v1/authorizationServers")
             verify(mockWebServer.takeRequest(), "GET", "/api/v1/apps", "q=test-project")
-            verifyRedirectUri(mockWebServer.takeRequest(), "http://localhost:8080/callback")
+            verifyRedirectUri(mockWebServer.takeRequest(), ["http://localhost:8080/callback"])
             verify(mockWebServer.takeRequest(), "GET", "/api/v1/groups", "q=everyone")
             verify(mockWebServer.takeRequest(), "PUT", "/api/v1/apps/test-app-id/groups/every1-id")
             verify(mockWebServer.takeRequest(), "GET", "/api/v1/internal/apps/test-app-id/settings/clientcreds")
@@ -119,15 +119,15 @@ class AppsCreateIT implements MockWebSupport, CreateAppSupport {
             assertThat result, resultMatches(0, allOf(
                                                             containsString("Okta application configuration:"),
                                                             containsString("okta.oauth2.client-id: test-id"),
-                                                            containsString("Enter your Redirect URI [localhost:/callback]:"),
-                                                            containsString("Enter your Post Logout Redirect URI [localhost:/]:"),
+                                                            containsString("Enter your Redirect URI(s) [localhost:/callback]:"),
+                                                            containsString("Enter your Post Logout Redirect URI(s) [localhost:/]:"),
                                                             containsString("okta.oauth2.issuer: ${url(mockWebServer,"/")}/oauth2/test-as"),
                                                             not(containsString("okta.oauth2.client-secret"))),
                                                         null)
 
             mockWebServer.takeRequest() // auth list request
             mockWebServer.takeRequest() // check if app exists
-            verifyRedirectUri(mockWebServer.takeRequest(), "localhost:/callback")
+            verifyRedirectUri(mockWebServer.takeRequest(), ["localhost:/callback"])
         }
     }
 
@@ -166,14 +166,63 @@ class AppsCreateIT implements MockWebSupport, CreateAppSupport {
             assertThat result, resultMatches(0, allOf(
                                                             containsString("Created OIDC application, client-id: test-id"),
                                                             containsString("Okta application configuration has been written to"),
-                                                            containsString("Enter your Redirect URI [http://localhost:8080/callback]:"),
-                                                            containsString("Enter your Post Logout Redirect URI [http://localhost:8080/]:"),
+                                                            containsString("Enter your Redirect URI(s) [http://localhost:8080/callback]:"),
+                                                            containsString("Enter your Post Logout Redirect URI(s) [http://localhost:8080/]:"),
                                                             containsString(".okta.env")),
                                                         null)
 
             mockWebServer.takeRequest() // auth list request
             mockWebServer.takeRequest() // check if app exists
-            verifyRedirectUri(mockWebServer.takeRequest(), "http://localhost:8080/callback")
+            verifyRedirectUri(mockWebServer.takeRequest(), ["http://localhost:8080/callback"])
+        }
+    }
+
+    @Test
+    void createWebAppMultipleRedirect() {
+        MockWebServer mockWebServer = createMockServer()
+        List<MockResponse> responses = [
+                // GET /api/v1/authorizationServers
+                jsonRequest('[{ "id": "test-as", "name": "test-as-name", "issuer": "' + url(mockWebServer,"/") + '/oauth2/test-as" }]'),
+                // GET /api/v1/apps?q=integration-tests
+                jsonRequest('[]'),
+                // POST /api/v1/apps
+                jsonRequest('{ "id": "test-app-id", "label": "test-app-name" }'),
+                // GET /api/v1/groups?q=everyone
+                jsonRequest("[${everyoneGroup()}]"),
+                // PUT /api/v1/apps/test-app-id/groups/every1-id
+                jsonRequest('{}'),
+                //GET /api/v1/internal/apps/test-app-id/settings/clientcreds
+                jsonRequest('{ "client_id": "test-id", "client_secret": "test-secret" }')]
+
+        mockWebServer.with {
+            responses.forEach { mockWebServer.enqueue(it) }
+
+            List<String> input = [
+                    "", // default of "test-project"
+                    "", //  default "web" type of app choice
+                    "", // generic OIDC app
+                    "http://localhost:8080/callback, http://localhost:8888/callback", // redirect uris
+                    "",  // default post logout redirect "http://localhost:8080/, http://localhost:8888/"
+                    "", // generic OIDC app
+            ]
+
+            def result = new CommandRunner()
+                    .withSdkConfig(url(mockWebServer,"/"))
+                    .runCommandWithInput(input,"--color=never", "apps", "create")
+
+            assertThat result, resultMatches(0, allOf(
+                    containsString("Created OIDC application, client-id: test-id"),
+                    containsString("Okta application configuration has been written to"),
+                    containsString("Enter your Redirect URI(s) [http://localhost:8080/callback]:"),
+                    containsString("Enter your Post Logout Redirect URI(s) [http://localhost:8080/, http://localhost:8888/]:"),
+                    containsString(".okta.env")),
+                    null)
+
+            mockWebServer.takeRequest() // auth list request
+            mockWebServer.takeRequest() // check if app exists
+            verifyRedirectUri(mockWebServer.takeRequest(),
+                              ["http://localhost:8080/callback", "http://localhost:8888/callback"],
+                              ["http://localhost:8080/", "http://localhost:8888/"])
         }
     }
 
@@ -251,22 +300,27 @@ class AppsCreateIT implements MockWebSupport, CreateAppSupport {
             assertThat result, resultMatches(0, allOf(
                                                             containsString("Created OIDC application, client-id: test-id"),
                                                             containsString("Okta application configuration has been written to"),
-                                                            containsString("Enter your Redirect URI [http://localhost:8080/login/oauth2/code/okta]:"),
-                                                            containsString("Enter your Post Logout Redirect URI [http://localhost:8080/]:"),
+                                                            containsString("Enter your Redirect URI(s) [http://localhost:8080/login/oauth2/code/okta]:"),
+                                                            containsString("Enter your Post Logout Redirect URI(s) [http://localhost:8080/]:"),
                                                             containsString("application.properties")),
                                                         null)
 
             mockWebServer.takeRequest() // auth list request
             mockWebServer.takeRequest() // check if app exists
-            verifyRedirectUri(mockWebServer.takeRequest(), "http://localhost:8080/login/oauth2/code/okta")
+            verifyRedirectUri(mockWebServer.takeRequest(), ["http://localhost:8080/login/oauth2/code/okta"])
         }
     }
 
-    private void verifyRedirectUri(RecordedRequest request, String... expectedRedirectUris) {
+    private void verifyRedirectUri(RecordedRequest request, List<String> expectedRedirectUris, List<String> expectedPostLogoutRedirectUris = null) {
         verify(request, "POST", "/api/v1/apps")
-        def body = new JsonSlurper().parse(request.getBody().inputStream())
-        String[] redirectUris = body.settings.oauthClient.redirect_uris
+        def body = new JsonSlurper().parseText(request.getBody().readUtf8())
+        List<String> redirectUris = body.settings.oauthClient.redirect_uris
         assertThat redirectUris, equalTo(expectedRedirectUris)
+
+        if (expectedPostLogoutRedirectUris != null) {
+            List<String> postLogoutUris = body.settings.oauthClient.post_logout_redirect_uris
+            assertThat postLogoutUris, equalTo(expectedPostLogoutRedirectUris)
+        }
     }
 
     private void verifyTrustedOrigins(RecordedRequest request, String expectedUri) {


### PR DESCRIPTION
Updates the JHipster application template to include the test redirect uri: http://localhost:8761/login/oauth2/code/oidc
Multiple post redirect URIs are also used now (still the base URL of the redirect uri by default)

Fixes: #75