### PR TITLE
Add tests for projects that have empty properties

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -47,6 +47,12 @@
         </dependency>
 
         <dependency>
+            <groupId>nu.studer</groupId>
+            <artifactId>java-ordered-properties</artifactId>
+            <version>1.0.4</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/common/src/test/groovy/com/okta/cli/common/config/PropertiesFilePropertiesSourceTest.groovy
+++ b/common/src/test/groovy/com/okta/cli/common/config/PropertiesFilePropertiesSourceTest.groovy
@@ -108,6 +108,41 @@ class PropertiesFilePropertiesSourceTest {
         assertThat readFromFile(configFile), is(expectedMergedResult)
     }
 
+    @Test
+    void exitingPropertyWithEmptyValue() {
+        File configFile = writeFile([
+                "spring.foo": "bar",
+                "spring.fooBar": "expected-value",
+                "spring.numbers.one": "1",
+                "empty-value": "",
+                "spring.numbers.two": "two"],
+                "addPropertiesWithNull")
+
+        Map<String, String> newProps = [
+                "spring.foo": "bar-new",
+                "a-new-key": "a-new-value"
+        ]
+
+        Map<String, String> expectedMergedResult = [
+                "spring.foo": "bar-new",
+                "spring.fooBar": "expected-value",
+                "spring.numbers.one": "1",
+                "empty-value": "",
+                "spring.numbers.two": "two",
+                "a-new-key": "a-new-value"
+        ]
+
+        def propsSource = new PropertiesFilePropertiesSource(configFile)
+        def props = propsSource.getProperties()
+
+        // empty properties are loaded as null values
+        assertThat props.get("empty-value"), is(nullValue())
+
+        propsSource.addProperties(newProps)
+        assertThat readFromFile(configFile), is(expectedMergedResult)
+        // when written to file, the become empty strings
+    }
+
     static File writeFile(Map data, String testName) {
         File tempFile = File.createTempFile(testName, "test.properties")
         tempFile.withWriter {


### PR DESCRIPTION
The underlying property reader (from the Okta SDK converts empty properties into null values, so when writing the existing values these need to be converted back to empty strings
Uses OrderedProperties to write out exiting props files to retain property order, this still removes whitespace, but its much easer on diff tool now

Adds test for empty value properties