### PR TITLE
Add support for JHipster + Micronaut

### DIFF
--- a/common/src/main/java/com/okta/cli/common/model/OidcProperties.java
+++ b/common/src/main/java/com/okta/cli/common/model/OidcProperties.java
@@ -184,10 +184,17 @@ public abstract class OidcProperties {
                 redirectUri = redirectUris.get(0);
             }
 
-            return Map.of(
-                    "quarkus.oidc.application-type", applicationType,
-                    "quarkus.oidc.authentication.redirect-path", URI.create(redirectUri).getPath()
-            );
+            String redirectPath = URI.create(redirectUri).getPath();
+            Map<String, String> props = new LinkedHashMap<>();
+            props.put("quarkus.oidc.application-type", applicationType);
+            props.put("quarkus.oidc.authentication.redirect-path", redirectPath);
+
+            // detect if it's a JHipster app
+            if (redirectPath.endsWith("/login/oauth2/code/oidc")) {
+                props.put("jhipster.oidc.logout-url", issuerUri + "/v1/logout");
+            }
+
+            return props;
         }
     }
 
@@ -202,7 +209,21 @@ public abstract class OidcProperties {
 
         @Override
         Map<String, String> getOidcClientProperties() {
-            return Collections.emptyMap();
+            String redirectUri = "/";
+            if (redirectUris != null && !redirectUris.isEmpty()) {
+                redirectUri = redirectUris.get(0);
+            }
+
+            String redirectPath = URI.create(redirectUri).getPath();
+            // detect if it's a JHipster app
+            if (redirectPath.endsWith("/login/oauth2/code/oidc")) {
+                return Map.of(
+                    "micronaut.security.oauth2.callback-uri", "/login/oauth2/code{/provider}"
+                );
+            } else {
+                return Collections.emptyMap();
+            }
+
         }
     }
 }

--- a/common/src/main/java/com/okta/cli/common/model/OidcProperties.java
+++ b/common/src/main/java/com/okta/cli/common/model/OidcProperties.java
@@ -51,6 +51,8 @@ public abstract class OidcProperties {
                     String packageJson = Files.readString(packageJsonFile.toPath());
                     if (packageJson.contains("generator-jhipster-quarkus")) {
                         return quarkus(applicationType);
+                    } else if (packageJson.contains("generator-jhipster-micronaut")) {
+                        return micronaut("oidc");
                     } // add other JHipster implementations here
 
                 } catch (IOException e) {
@@ -76,6 +78,14 @@ public abstract class OidcProperties {
 
     public static QuarkusOidcProperties quarkus(OpenIdConnectApplicationType applicationType) {
         return new QuarkusOidcProperties(applicationType);
+    }
+
+    public static MicronautOidcProperties micronaut() {
+        return micronaut("oidc");
+    }
+
+    public static MicronautOidcProperties micronaut(String tenantId) {
+        return new MicronautOidcProperties(tenantId);
     }
 
     public final String issuerUriPropertyName;
@@ -181,4 +191,18 @@ public abstract class OidcProperties {
         }
     }
 
+    public static class MicronautOidcProperties extends OidcProperties {
+        public MicronautOidcProperties(String tenantId) {
+            super(
+                format("micronaut.security.oauth2.clients.%s.openid.issuer", tenantId),
+                format("micronaut.security.oauth2.clients.%s.client-id", tenantId),
+                format("micronaut.security.oauth2.clients.%s.client-secret", tenantId)
+            );
+        }
+
+        @Override
+        Map<String, String> getOidcClientProperties() {
+            return Collections.emptyMap();
+        }
+    }
 }

--- a/common/src/test/groovy/com/okta/cli/common/model/OidcPropertiesTest.groovy
+++ b/common/src/test/groovy/com/okta/cli/common/model/OidcPropertiesTest.groovy
@@ -84,7 +84,8 @@ class OidcPropertiesTest {
             "quarkus.oidc.client-id": "test-client-id",
             "quarkus.oidc.credentials.secret": "test-client-secret",
             "quarkus.oidc.authentication.redirect-path": "/login/oauth2/code/oidc",
-            "quarkus.oidc.application-type": "service"
+            "quarkus.oidc.application-type": "service",
+            "jhipster.oidc.logout-url": "https://issuer.example.com/v1/logout"
         ]
 
         jhipsterPropertiesTest(packageJson, expected, OpenIdConnectApplicationType.SERVICE)
@@ -105,7 +106,8 @@ class OidcPropertiesTest {
                 "quarkus.oidc.client-id": "test-client-id",
                 "quarkus.oidc.credentials.secret": "test-client-secret",
                 "quarkus.oidc.authentication.redirect-path": "/login/oauth2/code/oidc",
-                "quarkus.oidc.application-type": "web-app"
+                "quarkus.oidc.application-type": "web-app",
+                "jhipster.oidc.logout-url": "https://issuer.example.com/v1/logout"
         ]
 
         jhipsterPropertiesTest(packageJson, expected)
@@ -153,7 +155,8 @@ class OidcPropertiesTest {
         Map<String, String> expected = [
                 "micronaut.security.oauth2.clients.oidc.openid.issuer": "https://issuer.example.com",
                 "micronaut.security.oauth2.clients.oidc.client-id": "test-client-id",
-                "micronaut.security.oauth2.clients.oidc.client-secret": "test-client-secret"
+                "micronaut.security.oauth2.clients.oidc.client-secret": "test-client-secret",
+                "micronaut.security.oauth2.callback-uri": "/login/oauth2/code{/provider}"
         ]
 
         jhipsterPropertiesTest(packageJson, expected)

--- a/common/src/test/groovy/com/okta/cli/common/model/OidcPropertiesTest.groovy
+++ b/common/src/test/groovy/com/okta/cli/common/model/OidcPropertiesTest.groovy
@@ -140,6 +140,25 @@ class OidcPropertiesTest {
         jhipsterPropertiesTest(null, expected)
     }
 
+    @Test
+    void jhipsterMicronautPropertiesDetectionTest() {
+
+        String packageJson ="""
+            "devDependencies": {
+                "generator-jhipster": "6.10.5",
+                "generator-jhipster-micronaut": "0.8.0",
+            }
+        """.stripLeading()
+
+        Map<String, String> expected = [
+                "micronaut.security.oauth2.clients.oidc.openid.issuer": "https://issuer.example.com",
+                "micronaut.security.oauth2.clients.oidc.client-id": "test-client-id",
+                "micronaut.security.oauth2.clients.oidc.client-secret": "test-client-secret"
+        ]
+
+        jhipsterPropertiesTest(packageJson, expected)
+    }
+
     private static jhipsterPropertiesTest(String packageJsonText, Map<String, String> expectedProperties, OpenIdConnectApplicationType appType = OpenIdConnectApplicationType.WEB) {
         // set the current working directory to a test dir
         File workingDir = File.createTempDir("jhipsterPropertiesDetectionTest-", "-test")


### PR DESCRIPTION
Related to this support, if we wanted to set up GitHub Actions to confirm that JHipster (and its blueprints) work with Okta, does the CLI allow you to set the `okta.client` parameters as environment variables? It'd be cool if we could configure the following workflow with the CLI:

1. Configure secrets in GitHub for `orgUrl`, `token`, and credentials for a user (for e2e tests).
2. Create a workflow that creates a JHipster app, runs the e2e tests, and destroys the app.
3. Profit! 😊

Fixes https://github.com/okta/okta-cli/issues/29.