### PR TITLE
Fix duplicate prompt header when choosing wev framework

### DIFF
--- a/cli/src/main/java/com/okta/cli/commands/apps/AppsCreate.java
+++ b/cli/src/main/java/com/okta/cli/commands/apps/AppsCreate.java
@@ -98,7 +98,7 @@ public class AppsCreate extends BaseCommand {
         ConsoleOutput out = getConsoleOutput();
         Prompter prompter = getPrompter();
 
-        WebAppTemplate appTemplate = prompter.promptIfEmpty(webAppTemplate, "Type of Application", WebAppTemplate.values(), WebAppTemplate.GENERIC);
+        WebAppTemplate appTemplate = prompter.promptIfEmpty(webAppTemplate, "Framework of Application", WebAppTemplate.values(), WebAppTemplate.GENERIC);
 
         List<String> redirectUris = getRedirectUris(Map.of("Spring Security", "http://localhost:8080/login/oauth2/code/okta",
                                                     "Quarkus OIDC", "http://localhost:8080/callback",

--- a/integration-tests/src/test/groovy/com/okta/cli/test/CommandRunner.groovy
+++ b/integration-tests/src/test/groovy/com/okta/cli/test/CommandRunner.groovy
@@ -104,6 +104,7 @@ class CommandRunner {
         }
 
         process.waitForOrKill(timeout().toMillis())
+        process.closeStreams()
 
         // flush the console output
         System.out.flush()


### PR DESCRIPTION
The CLI prompted for "Type of application" twice, once for the "type": web, spa, native, etc
and again for the framework when "Web" was selected, this has been renamed to "Framework of application"

Related to: okta/okta-developer-docs#2014