### PR TITLE
Update the registration process to use the new Okta registration API

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -71,16 +71,8 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
+            <artifactId>slf4j-jdk14</artifactId>
             <version>${slf4j.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-            <version>${slf4j.version}</version>
-            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/cli/src/main/graalvm/reflect-config.json
+++ b/cli/src/main/graalvm/reflect-config.json
@@ -30,6 +30,13 @@
     "allPublicFields": true
   },
   {
+    "name": "com.okta.cli.common.model.UserProfileRequestWrapper",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allPublicFields": true
+  },
+  {
     "name": "com.okta.cli.common.model.OrganizationResponse",
     "allDeclaredFields": true,
     "allDeclaredMethods": true,

--- a/cli/src/main/java/com/okta/cli/OktaCli.java
+++ b/cli/src/main/java/com/okta/cli/OktaCli.java
@@ -30,6 +30,10 @@ import picocli.CommandLine.Option;
 import picocli.CommandLine.Spec;
 
 import java.util.List;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
 
 @Command(name = "okta",
         description = "The Okta CLI helps you configure your applications to use Okta.",
@@ -110,9 +114,18 @@ public class OktaCli implements Runnable {
 
         @Option(names = "--verbose", description = "Verbose logging.")
         public void setVerbose(boolean verbose) {
-            this.environment.setVerbose(verbose);
+            environment.setVerbose(verbose);
             if (verbose) {
-                System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "debug");
+                // <ISO8601 date> <level> <logger> <message> <exception>
+                System.setProperty("java.util.logging.SimpleFormatter.format", "%1$tFT%1$tT.%1$tL%1$tz %4$s %2$s - %5$s\u001F%6$s%n");
+
+                final LogManager logManager = LogManager.getLogManager();
+                Logger rootLogger = logManager.getLogger("");
+                rootLogger.setLevel(Level.FINER);
+
+                ConsoleHandler consoleHandler = new ConsoleHandler();
+                consoleHandler.setLevel(Level.FINER);
+                rootLogger.addHandler(consoleHandler);
             }
         }
 

--- a/cli/src/main/java/com/okta/cli/commands/Register.java
+++ b/cli/src/main/java/com/okta/cli/commands/Register.java
@@ -44,6 +44,9 @@ public class Register extends BaseCommand {
     @CommandLine.Option(names = "--company", description = "Company/organization used when registering a new Okta account.")
     protected String company;
 
+    @CommandLine.Option(names = "--country", description = "Country of residence")
+    protected String country;
+
     public Register() {}
 
     private Register(OktaCli.StandardOptions standardOptions) {
@@ -76,7 +79,7 @@ public class Register extends BaseCommand {
                                    getEnvironment().isDemo(),
                                    getEnvironment().isInteractive());
 
-        String identifier = orgResponse.getId();
+        String identifier = orgResponse.getDeveloperOrgCliToken();
         setupService.verifyOktaOrg(identifier,
                 registrationQuestions,
                 getEnvironment().getOktaPropsFile());
@@ -104,12 +107,7 @@ public class Register extends BaseCommand {
                     .setFirstName(prompter.promptUntilValue(firstName, "First name"))
                     .setLastName(prompter.promptUntilValue(lastName, "Last name"))
                     .setEmail(prompter.promptUntilValue(email, "Email address"))
-                    .setOrganization(prompter.promptUntilValue(company, "Company"));
-        }
-
-        @Override
-        public String getVerificationCode() {
-            return prompter.promptUntilValue("Verification code");
+                    .setCountry(prompter.promptUntilValue(country, "Country"));
         }
     }
 }

--- a/cli/src/main/java/com/okta/cli/commands/Register.java
+++ b/cli/src/main/java/com/okta/cli/commands/Register.java
@@ -47,6 +47,9 @@ public class Register extends BaseCommand {
     @CommandLine.Option(names = "--country", description = "Country of residence")
     protected String country;
 
+    @CommandLine.Option(names = "--oie", description = "Create Okta account with OIE enabled.", defaultValue = "true", hidden = true, negatable = true)
+    protected Boolean oie = Boolean.TRUE;
+
     public Register() {}
 
     private Register(OktaCli.StandardOptions standardOptions) {
@@ -107,7 +110,8 @@ public class Register extends BaseCommand {
                     .setFirstName(prompter.promptUntilValue(firstName, "First name"))
                     .setLastName(prompter.promptUntilValue(lastName, "Last name"))
                     .setEmail(prompter.promptUntilValue(email, "Email address"))
-                    .setCountry(prompter.promptUntilValue(country, "Country"));
+                    .setCountry(prompter.promptUntilValue(country, "Country"))
+                    .setOie(oie);
         }
     }
 }

--- a/common/src/main/java/com/okta/cli/common/model/OrganizationRequest.java
+++ b/common/src/main/java/com/okta/cli/common/model/OrganizationRequest.java
@@ -16,6 +16,7 @@
 package com.okta.cli.common.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -28,4 +29,7 @@ public class OrganizationRequest {
     private String lastName;
     private String email;
     private String country;
+
+    @JsonProperty("okta_oie")
+    private Boolean oie;
 }

--- a/common/src/main/java/com/okta/cli/common/model/OrganizationRequest.java
+++ b/common/src/main/java/com/okta/cli/common/model/OrganizationRequest.java
@@ -15,15 +15,17 @@
  */
 package com.okta.cli.common.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
 @Data
 @Accessors(chain = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class OrganizationRequest {
 
     private String firstName;
     private String lastName;
     private String email;
-    private String organization;
+    private String country;
 }

--- a/common/src/main/java/com/okta/cli/common/model/OrganizationResponse.java
+++ b/common/src/main/java/com/okta/cli/common/model/OrganizationResponse.java
@@ -22,11 +22,12 @@ import lombok.experimental.Accessors;
 @Accessors(chain = true)
 public class OrganizationResponse {
 
-    private String id;
     private String orgUrl;
-    private String email;
     private String apiToken;
-    private String factorId;
-    private String updatePasswordUrl;
+    private String developerOrgCliToken;
+    private String status; // ACTIVE or PENDING
 
+    public boolean isActive() {
+        return "ACTIVE".equals(status);
+    }
 }

--- a/common/src/main/java/com/okta/cli/common/model/RegistrationQuestions.java
+++ b/common/src/main/java/com/okta/cli/common/model/RegistrationQuestions.java
@@ -21,21 +21,17 @@ public interface RegistrationQuestions {
 
     OrganizationRequest getOrganizationRequest();
 
-    String getVerificationCode();
-
-    static RegistrationQuestions answers(boolean overwriteConfig, OrganizationRequest request, String code) {
-        return new SimpleRegistrationQuestions(overwriteConfig, request, code);
+    static RegistrationQuestions answers(boolean overwriteConfig, OrganizationRequest request) {
+        return new SimpleRegistrationQuestions(overwriteConfig, request);
     }
 
     class SimpleRegistrationQuestions implements RegistrationQuestions {
         private final boolean overwriteConfig;
         private final OrganizationRequest organizationRequest;
-        private final String verificationCode;
 
-        public SimpleRegistrationQuestions(boolean overwriteConfig, OrganizationRequest organizationRequest, String verificationCode) {
+        public SimpleRegistrationQuestions(boolean overwriteConfig, OrganizationRequest organizationRequest) {
             this.overwriteConfig = overwriteConfig;
             this.organizationRequest = organizationRequest;
-            this.verificationCode = verificationCode;
         }
 
         public boolean isOverwriteExistingConfig(String oktaBaseUrl, String configFile) {
@@ -44,10 +40,6 @@ public interface RegistrationQuestions {
 
         public OrganizationRequest getOrganizationRequest() {
             return organizationRequest;
-        }
-
-        public String getVerificationCode() {
-            return verificationCode;
         }
     }
 }

--- a/common/src/main/java/com/okta/cli/common/model/UserProfileRequestWrapper.java
+++ b/common/src/main/java/com/okta/cli/common/model/UserProfileRequestWrapper.java
@@ -13,17 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.okta.cli.common;
+package com.okta.cli.common.model;
 
-import com.okta.cli.common.model.ErrorResponse;
+import lombok.Data;
+import lombok.experimental.Accessors;
 
-public class FactorVerificationException extends RestException {
+/**
+ * Okta's Registration API wraps the request in a "userProfile" node.
+ */
+@Data
+@Accessors(chain = true)
+public class UserProfileRequestWrapper {
 
-    public FactorVerificationException(ErrorResponse errorResponse, Throwable t) {
-        super(errorResponse, t);
-    }
+    private final OrganizationRequest userProfile;
 
-    public FactorVerificationException(ErrorResponse errorResponse) {
-        super(errorResponse);
+    public UserProfileRequestWrapper(OrganizationRequest userProfile) {
+        this.userProfile = userProfile;
     }
 }

--- a/common/src/main/java/com/okta/cli/common/service/DefaultOktaOrganizationCreator.java
+++ b/common/src/main/java/com/okta/cli/common/service/DefaultOktaOrganizationCreator.java
@@ -15,32 +15,27 @@
  */
 package com.okta.cli.common.service;
 
-import com.okta.cli.common.FactorVerificationException;
 import com.okta.cli.common.RestException;
 import com.okta.cli.common.model.OrganizationRequest;
 import com.okta.cli.common.model.OrganizationResponse;
+import com.okta.cli.common.model.UserProfileRequestWrapper;
 
 import java.io.IOException;
 
 public class DefaultOktaOrganizationCreator implements OktaOrganizationCreator {
 
-    private final RestClient restClient = new DefaultStartRestClient();
+    private final RestClient restClient = new DefaultStartRestClient(Settings.getRegistrationBaseUrl());
+
+    private final String registrationId = Settings.getRegistrationId();
 
     @Override
     public OrganizationResponse createNewOrg(OrganizationRequest orgRequest) throws RestException, IOException {
-
-        return restClient.post("/create", orgRequest, OrganizationResponse.class);
+        return restClient.post("/api/v1/registration/" + registrationId + "/register", new UserProfileRequestWrapper(orgRequest), OrganizationResponse.class);
     }
 
     @Override
-    public OrganizationResponse verifyNewOrg(String identifier, String code) throws FactorVerificationException, IOException {
-
-        String postBody = "{\"code\":\"" + code + "\"}";
-
-        try {
-            return restClient.post("/verify/" + identifier, postBody, OrganizationResponse.class);
-        } catch (RestException e) {
-            throw new FactorVerificationException(e.getErrorResponse(), e);
-        }
+    public OrganizationResponse verifyNewOrg(String identifier) throws RestException, IOException {
+        return restClient.get("/api/internal/v1/developer/redeem/" + identifier, OrganizationResponse.class);
     }
+
 }

--- a/common/src/main/java/com/okta/cli/common/service/DefaultSetupService.java
+++ b/common/src/main/java/com/okta/cli/common/service/DefaultSetupService.java
@@ -89,7 +89,7 @@ public class DefaultSetupService implements SetupService {
     public OrganizationResponse createOktaOrg(RegistrationQuestions registrationQuestions,
                                               File oktaPropsFile,
                                               boolean demo,
-                                              boolean interactive) throws IOException, ClientConfigurationException {
+                                              boolean interactive) throws IOException, ClientConfigurationException, UserCanceledException {
 
 
         // check if okta client config exists?
@@ -99,7 +99,7 @@ public class DefaultSetupService implements SetupService {
 
             if (!Strings.isEmpty(clientConfiguration.getBaseUrl())) {
                 if (!registrationQuestions.isOverwriteExistingConfig(clientConfiguration.getBaseUrl(), oktaPropsFile.getAbsolutePath())) {
-                    throw new ClientConfigurationException("User canceled");
+                    throw new UserCanceledException();
                 }
 
                 Instant instant = Instant.now();

--- a/common/src/main/java/com/okta/cli/common/service/OktaOrganizationCreator.java
+++ b/common/src/main/java/com/okta/cli/common/service/OktaOrganizationCreator.java
@@ -15,7 +15,6 @@
  */
 package com.okta.cli.common.service;
 
-import com.okta.cli.common.FactorVerificationException;
 import com.okta.cli.common.RestException;
 import com.okta.cli.common.model.OrganizationRequest;
 import com.okta.cli.common.model.OrganizationResponse;
@@ -26,5 +25,5 @@ public interface OktaOrganizationCreator {
 
     OrganizationResponse createNewOrg(OrganizationRequest orgRequest) throws IOException, RestException;
 
-    OrganizationResponse verifyNewOrg(String identifier, String code) throws FactorVerificationException, IOException;
+    OrganizationResponse verifyNewOrg(String identifier) throws IOException, RestException;
 }

--- a/common/src/main/java/com/okta/cli/common/service/Settings.java
+++ b/common/src/main/java/com/okta/cli/common/service/Settings.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.cli.common.service;
+
+class Settings {
+
+    /**
+     * The base URL of the service used to create a new Okta account.
+     * This value is NOT exposed as a plugin parameter, but CAN be set using the env var {@code OKTA_CLI_REGISTRATION_URL}.
+     */
+    private static final String DEFAULT_CLI_API_URL = "https://start.okta.dev/";
+    private static final String DEFAULT_REGISTRATION_BASE_URL = "https://okta-devok12.okta.com/";
+    private static final String DEFAULT_REGISTRATION_ID = "reg405abrRAkn0TRf5d6";
+
+    static String getProperty(String envVar, String systemProperty, String defaultValue) {
+        // Resolve baseURL via ENV Var, System property, and fallback to the default
+        return System.getenv().getOrDefault(envVar, // check env var first
+                System.getProperties().getProperty(systemProperty, // try system property
+                        defaultValue)); // fallback to default value
+    }
+
+    static String getRegistrationBaseUrl() {
+        return getProperty("OKTA_CLI_REGISTRATION_URL", "okta.cli.registrationUrl", DEFAULT_REGISTRATION_BASE_URL);
+    }
+
+    static String getRegistrationId() {
+        return getProperty("OKTA_CLI_REGISTRATION_ID", "okta.cli.registrationId", DEFAULT_REGISTRATION_ID);
+    }
+
+    static String getCliApiUrl() {
+        return getProperty("OKTA_CLI_API_URL", "okta.cli.apiUrl", DEFAULT_CLI_API_URL);
+    }
+}

--- a/common/src/main/java/com/okta/cli/common/service/SetupService.java
+++ b/common/src/main/java/com/okta/cli/common/service/SetupService.java
@@ -32,7 +32,7 @@ public interface SetupService {
     OrganizationResponse createOktaOrg(RegistrationQuestions registrationQuestions,
                                        File oktaPropsFile,
                                        boolean demo,
-                                       boolean interactive) throws IOException, ClientConfigurationException;
+                                       boolean interactive) throws IOException, ClientConfigurationException, UserCanceledException;
 
     void verifyOktaOrg(String identifier,
                        RegistrationQuestions registrationQuestions,

--- a/common/src/main/java/com/okta/cli/common/service/UserCanceledException.java
+++ b/common/src/main/java/com/okta/cli/common/service/UserCanceledException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.cli.common.service;
+
+public class UserCanceledException extends Exception {
+
+    public UserCanceledException() {
+        super();
+    }
+}

--- a/common/src/test/groovy/com/okta/cli/common/service/DefaultOrganizationCreatorTest.groovy
+++ b/common/src/test/groovy/com/okta/cli/common/service/DefaultOrganizationCreatorTest.groovy
@@ -33,13 +33,15 @@ class DefaultOrganizationCreatorTest implements WireMockSupport {
     @Override
     Collection<StubMapping> wireMockStubMapping() {
         return [
-                post("/create")
+                post("/api/v1/registration/reg405abrRAkn0TRf5d6/register")
                 .withRequestBody(equalToJson("""
                     {
-                      "firstName": "Joe",
-                      "lastName": "Coder",
-                      "email": "joe.coder@example.com",
-                      "organization": "Test co"
+                      "userProfile": {
+                          "firstName": "Joe",
+                          "lastName": "Coder",
+                          "email": "joe.coder@example.com",
+                          "country": "US of A"
+                        }
                     }
                     """))
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -53,18 +55,17 @@ class DefaultOrganizationCreatorTest implements WireMockSupport {
     @Test
     void basicSuccessTest() {
 
-        RestoreEnvironmentVariables.setEnvironmentVariable("OKTA_CLI_BASE_URL", mockUrl())
+        RestoreEnvironmentVariables.setEnvironmentVariable("OKTA_CLI_REGISTRATION_URL", mockUrl())
 
         DefaultOktaOrganizationCreator creator = new DefaultOktaOrganizationCreator()
         OrganizationResponse response = creator.createNewOrg(new OrganizationRequest()
             .setEmail("joe.coder@example.com")
-            .setOrganization("Test co")
+            .setCountry("US of A")
             .setFirstName("Joe")
             .setLastName("Coder"))
 
         assertThat response.orgUrl, is("https://okta.example.com")
         assertThat response.apiToken, is("an-api-token-here")
-        assertThat response.email, is("joe.coder@example.com")
     }
 
     private String basicSuccess() {

--- a/integration-tests/src/test/groovy/com/okta/cli/test/AppsCreateIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/cli/test/AppsCreateIT.groovy
@@ -373,7 +373,7 @@ class AppsCreateIT implements MockWebSupport, CreateAppSupport {
 
             def result = new CommandRunner()
                     .withSdkConfig(url(mockWebServer,"/"))
-                    .runCommandWithInput(input,"--verbose", "--color=never", "apps", "create")
+                    .runCommandWithInput(input,"--color=never", "apps", "create")
 
             assertThat result, resultMatches(0, allOf(
                                                             containsString("Created OIDC application, client-id: test-id"),

--- a/integration-tests/src/test/groovy/com/okta/cli/test/AppsDeleteIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/cli/test/AppsDeleteIT.groovy
@@ -46,7 +46,7 @@ class AppsDeleteIT implements MockWebSupport, CreateAppSupport {
 
             def result = new CommandRunner()
                     .withSdkConfig(mockWebServer.url("/").toString())
-                    .runCommandWithInput(input, "--color=never", "apps", "delete", "--verbose", "app-id1")
+                    .runCommandWithInput(input, "--color=never", "apps", "delete", "app-id1")
 
             assertThat result, resultMatches(0, allOf(
                     containsString("Deactivate and delete application 'app-id1'? [y/N]"),
@@ -107,7 +107,7 @@ class AppsDeleteIT implements MockWebSupport, CreateAppSupport {
 
             def result = new CommandRunner()
                     .withSdkConfig(mockWebServer.url("/").toString())
-                    .runCommandWithInput(input, "--color=never", "apps", "delete", "--verbose", "app-id1")
+                    .runCommandWithInput(input, "--color=never", "apps", "delete", "app-id1")
 
             assertThat result, resultMatches(0, allOf(
                         containsString("Deactivate and delete application 'app-id1'? [y/N]"),
@@ -134,7 +134,7 @@ class AppsDeleteIT implements MockWebSupport, CreateAppSupport {
 
             def result = new CommandRunner()
                     .withSdkConfig(mockWebServer.url("/").toString())
-                    .runCommandWithInput(input, "--color=never", "apps", "delete", "--verbose", "app-id1")
+                    .runCommandWithInput(input, "--color=never", "apps", "delete", "app-id1")
 
             assertThat result, resultMatches(1, containsString("Application 'app-id1' has already been marked for deletion"),
                     null)
@@ -161,7 +161,7 @@ class AppsDeleteIT implements MockWebSupport, CreateAppSupport {
 
             def result = new CommandRunner()
                     .withSdkConfig(mockWebServer.url("/").toString())
-                    .runCommandWithInput(input, "--color=never", "apps", "delete", "--verbose", "app-id1")
+                    .runCommandWithInput(input, "--color=never", "apps", "delete", "app-id1")
 
             assertThat result, resultMatches(1, allOf(
                     containsString("Deactivate and delete application 'app-id1'? [y/N]")),
@@ -219,7 +219,7 @@ class AppsDeleteIT implements MockWebSupport, CreateAppSupport {
 
             def result = new CommandRunner()
                     .withSdkConfig(mockWebServer.url("/").toString())
-                    .runCommandWithInput(input, "--color=never", "apps", "delete", "--verbose", "app-id1", "app-id2")
+                    .runCommandWithInput(input, "--color=never", "apps", "delete", "app-id1", "app-id2")
 
             assertThat result, resultMatches(1, allOf(
                     containsString("Deactivate and delete application 'app-id1'? [y/N]"),

--- a/integration-tests/src/test/groovy/com/okta/cli/test/CommandRunner.groovy
+++ b/integration-tests/src/test/groovy/com/okta/cli/test/CommandRunner.groovy
@@ -82,7 +82,7 @@ class CommandRunner {
 
         String homeDirString = escapePath(homeDir.absolutePath)
 
-        List<String> command = [getCli(homeDir), "-Duser.home=${homeDirString}", "-Dokta.testing.disableHttpsCheck=true", "-Dokta.cli.baseUrl=${regServiceUrl}"]
+        List<String> command = [getCli(homeDir), "-Duser.home=${homeDirString}", "-Dokta.testing.disableHttpsCheck=true", "-Dokta.cli.registrationUrl=${regServiceUrl}", "-Dokta.cli.apiUrl=${regServiceUrl}"]
         command.addAll(args)
 
         String cmd = command.join(" ")

--- a/integration-tests/src/test/groovy/com/okta/cli/test/CreateAppSupport.groovy
+++ b/integration-tests/src/test/groovy/com/okta/cli/test/CreateAppSupport.groovy
@@ -46,7 +46,7 @@ trait CreateAppSupport {
         ]
     }
 
-    void verifyOrgCreateRequest(RecordedRequest request, String firstName = "test-first", String lastName = "test-last", String email = "test-email@example.com", String company = "test co") {
+    void verifyOrgCreateRequest(RecordedRequest request, String firstName = "test-first", String lastName = "test-last", String email = "test-email@example.com", String country = "Petoria") {
         assertThat request.getRequestLine(), equalTo("POST /create HTTP/1.1")
         assertThat request.getHeader("Content-Type"), equalTo("application/json")
         Map body = new JsonSlurper().parse(request.getBody().readByteArray(), StandardCharsets.UTF_8.toString())
@@ -54,7 +54,7 @@ trait CreateAppSupport {
                 firstName: firstName,
                 lastName: lastName,
                 email: email,
-                organization: company
+                country: country
         ])
     }
 

--- a/integration-tests/src/test/groovy/com/okta/cli/test/RegisterIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/cli/test/RegisterIT.groovy
@@ -34,8 +34,8 @@ class RegisterIT implements MockWebSupport {
     void happyPath() {
 
         List<MockResponse> responses = [
-                jsonRequest('{ "orgUrl": "https://result.example.com", "email": "test-email@example.com", "id": "test-id" }'),
-                jsonRequest('{ "orgUrl": "https://result.example.com", "email": "test-email@example.com", "apiToken": "fake-test-token" }')
+                jsonRequest('{ "orgUrl": "https://result.example.com", "email": "test-email@example.com", "developerOrgCliToken": "test-id" }'),
+                jsonRequest('{ "orgUrl": "https://result.example.com", "email": "test-email@example.com", "apiToken": "fake-test-token", "status": "ACTIVE" }')
         ]
 
         MockWebServer mockWebServer = createMockServer()
@@ -46,23 +46,24 @@ class RegisterIT implements MockWebSupport {
                     "test-first",
                     "test-last",
                     "test-email@example.com",
-                    "test co",
-                    "123456"
+                    "Petoria",
             ]
 
             def result = new CommandRunner(url(mockWebServer, "/")).runCommandWithInput(input, "register", "--verbose")
-            assertThat result, resultMatches(0, allOf(containsString("An email has been sent to you with a verification code."), containsString("Verification code")), emptyString())
+            assertThat result, resultMatches(0, allOf(containsString("An account activation email has been sent to you.")), emptyString())
 
 
             RecordedRequest request = mockWebServer.takeRequest()
-            assertThat request.getRequestLine(), equalTo("POST /create HTTP/1.1")
+            assertThat request.getRequestLine(), equalTo("POST /api/v1/registration/reg405abrRAkn0TRf5d6/register HTTP/1.1")
             assertThat request.getHeader("Content-Type"), is("application/json")
             Map body = new JsonSlurper().parse(request.getBody().readByteArray(), StandardCharsets.UTF_8.toString())
             assertThat body, equalTo([
+                userProfile: [
                     firstName: "test-first",
                     lastName: "test-last",
                     email: "test-email@example.com",
-                    organization: "test co"
+                    country: "Petoria"
+                ]
             ])
 
             File oktaConfigFile = new File(result.homeDir, ".okta/okta.yaml")
@@ -74,8 +75,8 @@ class RegisterIT implements MockWebSupport {
     void existingConfigFile_overwrite() {
 
         List<MockResponse> responses = [
-                jsonRequest('{ "orgUrl": "https://result.example.com", "email": "test-email@example.com", "id": "test-id" }'),
-                jsonRequest('{ "orgUrl": "https://result.example.com", "email": "test-email@example.com", "apiToken": "fake-test-token" }')
+                jsonRequest('{ "orgUrl": "https://result.example.com", "email": "test-email@example.com", "developerOrgCliToken": "test-id" }'),
+                jsonRequest('{ "orgUrl": "https://result.example.com", "email": "test-email@example.com", "apiToken": "fake-test-token", "status": "ACTIVE" }\') }')
         ]
 
         MockWebServer mockWebServer = createMockServer()
@@ -87,8 +88,7 @@ class RegisterIT implements MockWebSupport {
                     "test-first",
                     "test-last",
                     "test-email@example.com",
-                    "test co",
-                    "123456"
+                    "Petoria"
             ]
 
             CommandRunner runner = new CommandRunner(url(mockWebServer, "/"))
@@ -104,17 +104,19 @@ okta:
                     }
 
             def result = runner.runCommandWithInput(input, "register")
-            assertThat result, resultMatches(0, allOf(containsString("An email has been sent to you with a verification code."), containsString("Verification code")), emptyString())
+            assertThat result, resultMatches(0, containsString("An account activation email has been sent to you."), emptyString())
 
             RecordedRequest request = mockWebServer.takeRequest()
-            assertThat request.getRequestLine(), equalTo("POST /create HTTP/1.1")
+            assertThat request.getRequestLine(), equalTo("POST /api/v1/registration/reg405abrRAkn0TRf5d6/register HTTP/1.1")
             assertThat request.getHeader("Content-Type"), is("application/json")
             Map body = new JsonSlurper().parse(request.getBody().readByteArray(), StandardCharsets.UTF_8.toString())
             assertThat body, equalTo([
+                userProfile: [
                     firstName: "test-first",
                     lastName: "test-last",
                     email: "test-email@example.com",
-                    organization: "test co"
+                    country: "Petoria"
+                ]
             ])
 
             File oktaConfigFile = new File(result.homeDir, ".okta/okta.yaml")
@@ -150,17 +152,11 @@ okta:
     }
 
     @Test
-    void invalidCodeTest() {
+    void pollingTest() {
         List<MockResponse> responses = [
-                jsonRequest('{ "orgUrl": "https://result.example.com", "email": "test-email@example.com", "id": "test-id" }'),
-                jsonRequest(new ErrorResponse()
-                        .setError("Invalid passcode")
-                        .setMessage("Test message")
-                        .setCauses(["error 1", "error 2"])
-                        .setStatus(401),
-                        401
-                ),
-                jsonRequest('{ "orgUrl": "https://result.example.com", "email": "test-email@example.com", "apiToken": "fake-test-token" }')
+                jsonRequest('{ "orgUrl": "https://result.example.com", "email": "test-email@example.com", "developerOrgCliToken": "test-id" }'),
+                jsonRequest('{ "status": "PENDING" }'),
+                jsonRequest('{ "orgUrl": "https://result.example.com", "email": "test-email@example.com", "apiToken": "fake-test-token", "status": "ACTIVE" }')
         ]
 
         MockWebServer mockWebServer = createMockServer()
@@ -171,23 +167,23 @@ okta:
                     "test-first",
                     "test-last",
                     "test-email@example.com",
-                    "test co",
-                    "123456",
-                    "654321"
+                    "Petoria"
             ]
 
             def result = new CommandRunner(url(mockWebServer, "/")).runCommandWithInput(input, "register")
-            assertThat result, resultMatches(0, allOf(containsString("An email has been sent to you with a verification code."), containsString("Verification code")), emptyString())
+            assertThat result, resultMatches(0, containsString("An account activation email has been sent to you."), emptyString())
 
             RecordedRequest request = mockWebServer.takeRequest()
-            assertThat request.getRequestLine(), equalTo("POST /create HTTP/1.1")
+            assertThat request.getRequestLine(), equalTo("POST /api/v1/registration/reg405abrRAkn0TRf5d6/register HTTP/1.1")
             assertThat request.getHeader("Content-Type"), is("application/json")
             Map body = new JsonSlurper().parse(request.getBody().readByteArray(), StandardCharsets.UTF_8.toString())
             assertThat body, equalTo([
+                userProfile: [
                     firstName: "test-first",
                     lastName: "test-last",
                     email: "test-email@example.com",
-                    organization: "test co"
+                    country: "Petoria"
+                ]
             ])
 
             File oktaConfigFile = new File(result.homeDir, ".okta/okta.yaml")

--- a/integration-tests/src/test/groovy/com/okta/cli/test/RegisterIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/cli/test/RegisterIT.groovy
@@ -48,7 +48,7 @@ class RegisterIT implements MockWebSupport {
                     "Petoria",
             ]
 
-            def result = new CommandRunner(url(mockWebServer, "/")).runCommandWithInput(input, "register", "--verbose")
+            def result = new CommandRunner(url(mockWebServer, "/")).runCommandWithInput(input, "register")
             assertThat result, resultMatches(0, allOf(containsString("An account activation email has been sent to you.")), emptyString())
 
 

--- a/integration-tests/src/test/groovy/com/okta/cli/test/RegisterIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/cli/test/RegisterIT.groovy
@@ -153,7 +153,7 @@ class RegisterIT implements MockWebSupport {
                     }
 
         def result = runner.runCommandWithInput(input, "register")
-        assertThat result, resultMatches(1, containsString("Overwrite configuration file?"), containsString("User canceled"))
+        assertThat result, resultMatches(2, containsString("Overwrite configuration file?"), emptyString())
 
         File oktaConfigFile = new File(result.homeDir, ".okta/okta.yaml")
         assertThat oktaConfigFile, new OktaConfigMatcher("https://test.example.com", "test-token")

--- a/integration-tests/src/test/groovy/com/okta/cli/test/StartIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/cli/test/StartIT.groovy
@@ -48,8 +48,8 @@ class StartIT implements MockWebSupport, CreateAppSupport {
 
         List<MockResponse> responses = [
                 // reg requests
-                jsonRequest('{ "orgUrl": "' + orgUrl + '", "email": "test-email@example.com", "id": "test-id" }'),
-                jsonRequest('{ "orgUrl": "' + orgUrl + '", "email": "test-email@example.com", "apiToken": "fake-test-token", "updatePasswordUrl": "' + orgUrl + 'password-reset-link"}'),
+                jsonRequest('{ "orgUrl": "' + orgUrl + '", "email": "test-email@example.com", "developerOrgCliToken": "test-id" }'),
+                jsonRequest('{ "orgUrl": "' + orgUrl + '", "email": "test-email@example.com", "apiToken": "fake-test-token", "status": "ACTIVE" }'),
 
                 // list samples
                 jsonRequest([items: [
@@ -86,9 +86,8 @@ class StartIT implements MockWebSupport, CreateAppSupport {
                     "test-first",
                     "test-last",
                     "test-email@example.com",
-                    "test co",
-                    "123456",
-                    "", // accept prompt to change password
+                    "Petoria",
+                    "", // accept prompt to continue
                     // select a sample
                     "2"
             ]
@@ -96,8 +95,7 @@ class StartIT implements MockWebSupport, CreateAppSupport {
             def result = new CommandRunner(url(mockWebServer, "/")).runCommandWithInput(input, "start")
             assertThat result, resultMatches(0, allOf(
                         // registration
-                        containsString("An email has been sent to you with a verification code."),
-                        containsString("Verification code"),
+                        containsString("An account activation email has been sent to you."),
                         containsString("Select a sample"),
                         containsString("a test description"),
                         containsString("Change the directory:"),


### PR DESCRIPTION
- start.okta.dev is still used for listing of the samples
- There are now two properties/env vars for the ITs to set: `okta.cli.registrationUrl` and `okta.cli.apiUrl`
- registration now asks for country instead of company