### PR TITLE
Return useful error message when running "apps create" and not logged in

### DIFF
--- a/cli/src/main/java/com/okta/cli/commands/apps/AppsCreate.java
+++ b/cli/src/main/java/com/okta/cli/commands/apps/AppsCreate.java
@@ -28,6 +28,7 @@ import com.okta.cli.common.service.DefaultSetupService;
 import com.okta.cli.console.ConsoleOutput;
 import com.okta.cli.console.Prompter;
 import com.okta.commons.lang.Assert;
+import com.okta.commons.lang.Strings;
 import com.okta.sdk.client.Client;
 import com.okta.sdk.client.Clients;
 import com.okta.sdk.resource.application.OpenIdConnectApplicationType;
@@ -44,6 +45,8 @@ import java.util.stream.Collectors;
 @CommandLine.Command(name = "create",
         description = "Create an new Okta app")
 public class AppsCreate extends BaseCommand {
+
+    private static final String NO_BASE_URL_ERROR = "Unable to find base URL, run `okta login` and try again";
 
     @CommandLine.Mixin
     private AppCreationMixin appCreationMixin;
@@ -196,10 +199,13 @@ public class AppsCreate extends BaseCommand {
 
     private String getBaseUrl() {
         try {
-            // TODO more hacking
-            return new DefaultSdkConfigurationService().loadUnvalidatedConfiguration().getBaseUrl();
+            String baseUrl = new DefaultSdkConfigurationService().loadUnvalidatedConfiguration().getBaseUrl();
+            if (Strings.isEmpty(baseUrl)) {
+                throw new IllegalStateException(NO_BASE_URL_ERROR);
+            }
+            return baseUrl;
         } catch (ClientConfigurationException e) {
-            throw new IllegalStateException("Unable to find base URL, run `okta login` and try again");
+            throw new IllegalStateException(NO_BASE_URL_ERROR, e);
         }
     }
 

--- a/integration-tests/src/test/groovy/com/okta/cli/test/AppsCreateIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/cli/test/AppsCreateIT.groovy
@@ -236,6 +236,20 @@ class AppsCreateIT implements MockWebSupport, CreateAppSupport {
     }
 
     @Test
+    void createAppNativeNotLoggedIn() {
+
+        List<String> input = [
+                "",  // default of "test-project"
+        ]
+
+        def result = new CommandRunner()
+                .runCommandWithInput(input,"--color=never", "apps", "create", "native")
+
+        assertThat result, resultMatches(1, null,
+                containsString("Unable to find base URL, run `okta login` and try again"))
+    }
+
+    @Test
     void createWebApp() {
         MockWebServer mockWebServer = createMockServer()
         List<MockResponse> responses = [


### PR DESCRIPTION
Example output:

```txt
Application name [example]:
Type of Application
(The Okta CLI only supports a subset of application types and properties):
> 1: Web
> 2: Single Page App
> 3: Native App (mobile)
> 4: Service (Machine-to-Machine)
Enter your choice [Web]: 3

An error occurred if you need more detail use the '--verbose' option

Unable to find base URL, run `okta login` and try again
```

Fixes: #191