### PR TITLE
Update Grammar and Language in Help

### DIFF
--- a/cli/src/main/java/com/okta/cli/OktaCli.java
+++ b/cli/src/main/java/com/okta/cli/OktaCli.java
@@ -103,12 +103,12 @@ public class OktaCli implements Runnable {
             environment.setConsoleColors(color == ColorOptions.always);
         }
 
-        @Option(names = "--batch", description = "Batch mode, will not prompt for user input")
+        @Option(names = "--batch", description = "Batch mode. Will not prompt for user input.")
         public void setBatch(boolean batch) {
             environment.setInteractive(!batch);
         }
 
-        @Option(names = "--verbose", description = "Verbose logging")
+        @Option(names = "--verbose", description = "Verbose logging.")
         public void setVerbose(boolean verbose) {
             this.environment.setVerbose(verbose);
             if (verbose) {
@@ -120,7 +120,7 @@ public class OktaCli implements Runnable {
             return getEnvironment().isVerbose();
         }
 
-        @Option(names = "-D", hidden = true, description = "Set Java System Property key value pairs", paramLabel = "<key=value>")
+        @Option(names = "-D", hidden = true, description = "Set Java System Property key value pairs.", paramLabel = "<key=value>")
         public void setSystemProperties(List<String> props) {
             if (props != null) {
                 props.forEach(it -> {

--- a/cli/src/main/java/com/okta/cli/commands/Logs.java
+++ b/cli/src/main/java/com/okta/cli/commands/Logs.java
@@ -39,7 +39,7 @@ import static java.lang.Thread.sleep;
                      hidden = true)
 public class Logs extends BaseCommand {
 
-    @CommandLine.Option(names = {"-f", "--follow"}, description = "Polls for new log events")
+    @CommandLine.Option(names = {"-f", "--follow"}, description = "Polls for new log events.")
     protected boolean follow;
 
     @Override

--- a/cli/src/main/java/com/okta/cli/commands/Register.java
+++ b/cli/src/main/java/com/okta/cli/commands/Register.java
@@ -32,16 +32,16 @@ import picocli.CommandLine.Command;
          description = "Sign up for a new Okta account")
 public class Register extends BaseCommand {
 
-    @CommandLine.Option(names = "--email", description = "Email used when registering a new Okta account")
+    @CommandLine.Option(names = "--email", description = "Email used when registering a new Okta account.")
     protected String email;
 
-    @CommandLine.Option(names = "--first-name", description = "First name used when registering a new Okta account")
+    @CommandLine.Option(names = "--first-name", description = "First name used when registering a new Okta account.")
     protected String firstName;
 
-    @CommandLine.Option(names = "--last-name", description = "Last name used when registering a new Okta account")
+    @CommandLine.Option(names = "--last-name", description = "Last name used when registering a new Okta account.")
     protected String lastName;
 
-    @CommandLine.Option(names = "--company", description = "Company / organization used when registering a new Okta account")
+    @CommandLine.Option(names = "--company", description = "Company/organization used when registering a new Okta account.")
     protected String company;
 
     public Register() {}

--- a/cli/src/main/java/com/okta/cli/commands/Start.java
+++ b/cli/src/main/java/com/okta/cli/commands/Start.java
@@ -61,7 +61,7 @@ public class Start extends BaseCommand {
     @CommandLine.Parameters(description = "Name of sample", arity = "0..1")
     private String sampleName;
 
-    @CommandLine.Option(names = {"--branch", "-b"}, description = "GitHub branch to use", hidden = true, defaultValue = "main")
+    @CommandLine.Option(names = {"--branch", "-b"}, description = "GitHub branch to use.", hidden = true, defaultValue = "main")
     private String branchName;
 
     @Override

--- a/cli/src/main/java/com/okta/cli/commands/apps/AppCreationMixin.java
+++ b/cli/src/main/java/com/okta/cli/commands/apps/AppCreationMixin.java
@@ -26,13 +26,13 @@ public class AppCreationMixin {
     @CommandLine.Option(names = "--config-file", description = {"Application config file, will search for:", " - src/main/resources/application.yml", " - src/main/resources/application.properties", " - .okta.env" })
     public File configFile;
 
-    @CommandLine.Option(names = "--app-name", description = "Application name to be created, defaults to current directory name")
+    @CommandLine.Option(names = "--app-name", description = "Application name to be created, defaults to current directory name.")
     public String appName;
 
-    @CommandLine.Option(names = "--authorization-server-id", description = "Okta Authorization Server Id")
+    @CommandLine.Option(names = "--authorization-server-id", description = "Okta Authorization Server Id.")
     public String authorizationServerId;
 
-    @CommandLine.Option(names = "--redirect-uri", description = "OIDC Redirect URI")
+    @CommandLine.Option(names = "--redirect-uri", description = "OIDC Redirect URI.")
     public String redirectUri;
 
     public MutablePropertySource getPropertySource(String defaultConfigFile) {

--- a/cli/src/main/java/com/okta/cli/commands/apps/AppsConfig.java
+++ b/cli/src/main/java/com/okta/cli/commands/apps/AppsConfig.java
@@ -31,7 +31,7 @@ import picocli.CommandLine;
         description = "Show an Okta app's configuration")
 public class AppsConfig extends BaseCommand {
 
-    @CommandLine.Option(names = "--app", description = "App ID", required = true)
+    @CommandLine.Option(names = "--app", description = "App ID.", required = true)
     private String appName;
 
     @Override

--- a/cli/src/main/java/com/okta/cli/commands/apps/AppsCreate.java
+++ b/cli/src/main/java/com/okta/cli/commands/apps/AppsCreate.java
@@ -43,7 +43,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 @CommandLine.Command(name = "create",
-        description = "Create an new Okta app")
+        description = "Create a new Okta app")
 public class AppsCreate extends BaseCommand {
 
     private static final String NO_BASE_URL_ERROR = "Unable to find base URL, run `okta login` and try again";

--- a/cli/src/main/java/com/okta/cli/commands/apps/AppsDelete.java
+++ b/cli/src/main/java/com/okta/cli/commands/apps/AppsDelete.java
@@ -32,7 +32,7 @@ public class AppsDelete extends BaseCommand {
     @CommandLine.Parameters(index="0..*", arity = "1..*", description = "List of application IDs to be deleted")
     private List<String> appIds;
 
-    @CommandLine.Option(names = {"-f", "--force"}, description = "Deactivate and delete applications")
+    @CommandLine.Option(names = {"-f", "--force"}, description = "Deactivate and delete applications.")
     private boolean force = false;
 
     @Override


### PR DESCRIPTION
## Add periods to Option descriptions
Adding periods to the end of all option descriptions; this provides consistency with pococli's existing convention on the standard help and version options which are also included in the app (the standard help and version options use periods).

## Correct grammar in Apps Create description
Change description from "Create an new Okta app" to "Create a new Okta app"