### PR TITLE
Ensure `okta start` prompt order is sorted correctly

### DIFF
--- a/cli/src/main/java/com/okta/cli/console/DefaultPrompter.java
+++ b/cli/src/main/java/com/okta/cli/console/DefaultPrompter.java
@@ -22,8 +22,11 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -89,7 +92,7 @@ public class DefaultPrompter implements Prompter, Closeable {
 
         Map<String, PromptOption<T>> choices = IntStream.range(0, options.size())
                 .boxed()
-                .collect(Collectors.toMap(index -> Integer.toString(index + 1), options::get));
+                .collect(orderedMap(index -> Integer.toString(index + 1), options::get));
 
         out.write(message + "\n");
         choices.forEach((key, value) -> {
@@ -126,5 +129,10 @@ public class DefaultPrompter implements Prompter, Closeable {
     public void close() throws IOException {
         out.close();
         consoleReader.close();
+    }
+
+    private static <T, K, U, M extends Map<K, U>> Collector<T, ?, M> orderedMap(Function<? super T, ? extends K> keyMapper,
+                                                                                Function<? super T, ? extends U> valueMapper) {
+        return (Collector<T, ?, M>) Collectors.toMap(keyMapper, valueMapper, (x, y) -> y, LinkedHashMap::new);
     }
 }

--- a/cli/src/test/groovy/com/okta/cli/console/DefaultPrompterTest.groovy
+++ b/cli/src/test/groovy/com/okta/cli/console/DefaultPrompterTest.groovy
@@ -136,6 +136,50 @@ class DefaultPrompterTest {
     }
 
     @Test
+    void promptOptions_moreThan10() {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream()
+        ConsoleOutput out = new ConsoleOutput.AnsiConsoleOutput(new PrintStream(outputStream), true)
+
+        expectInput("1")
+        DefaultPrompter prompter = new DefaultPrompter(out)
+
+        def options = [
+                new StubPromptOption("one", "one-1"),
+                new StubPromptOption("two", "two-2"),
+                new StubPromptOption("three", "three-3"),
+                new StubPromptOption("four", "four-4"),
+                new StubPromptOption("five", "five-5"),
+                new StubPromptOption("six", "six-6"),
+                new StubPromptOption("seven", "seven-7"),
+                new StubPromptOption("eight", "eight-8"),
+                new StubPromptOption("nine", "nine-9"),
+                new StubPromptOption("ten", "ten-10"),
+                new StubPromptOption("eleven", "eleven-11"),
+                new StubPromptOption("twelve", "twelve-12")
+        ]
+        String result = prompter.prompt("hello", options, options[0])
+
+        // ansi colors
+        String expectedOutput = "hello\n" +
+                "\u001B[1m> 1: \u001B[0mone\n" +
+                "\u001B[1m> 2: \u001B[0mtwo\n" +
+                "\u001B[1m> 3: \u001B[0mthree\n" +
+                "\u001B[1m> 4: \u001B[0mfour\n" +
+                "\u001B[1m> 5: \u001B[0mfive\n" +
+                "\u001B[1m> 6: \u001B[0msix\n" +
+                "\u001B[1m> 7: \u001B[0mseven\n" +
+                "\u001B[1m> 8: \u001B[0meight\n" +
+                "\u001B[1m> 9: \u001B[0mnine\n" +
+                "\u001B[1m> 10: \u001B[0mten\n" +
+                "\u001B[1m> 11: \u001B[0meleven\n" +
+                "\u001B[1m> 12: \u001B[0mtwelve\n" +
+                "Enter your choice [one]: "
+
+        assertThat(result, equalTo("one-1"))
+        assertThat(outputStream.toString(), equalTo(expectedOutput))
+    }
+
+    @Test
     void failToReadLine() {
         ConsoleOutput out = mock(ConsoleOutput)
         System.in = mock(InputStream)


### PR DESCRIPTION
The previous sample sort order was wrong:

```txt
Select a sample
> 11: Golang Gin API + Okta
> 1: Spring Boot + Okta
> 2: Vue + Okta
> 3: ASP.NET Core MVC + Okta
> 4: Angular + Okta
> 5: React Native + Okta
> 6: React + Okta
> 7: Android Java + Okta
> 8: Python Flask + Okta
> 9: Node.js Express + Okta
> 10: Golang Gin + Okta
```

<hr/>

This change fixes the ordering (and adds a test)