### PR TITLE
Added support for .bash_profile as well as .bashrc

### DIFF
--- a/cli/src/main/scripts/install.sh
+++ b/cli/src/main/scripts/install.sh
@@ -64,7 +64,7 @@ function install {
 
   } || { # catch
      echoerr
-     echoerr "Failed to install the okta cli.  Run the following command manually:"
+     echoerr "Failed to install the Okta CLI. Please run the following command manually:"
      echoerr "  mv -f $DOWNLOAD_LOCATION $HOME/bin"
      exit 1
   }
@@ -79,7 +79,7 @@ function install {
     [ -f "$HOME/.zshrc" ] && updateZshPath && PATH_UPDATED=true
 
     if [[ ! "$PATH_UPDATED" == "true" ]]; then
-      echoerr 'Failed to add $HOME/bin/okta to your path'
+      echoerr 'Failed to add $HOME/bin/okta to your path.'
       exit 1
     fi
   fi
@@ -94,7 +94,7 @@ function updateBashPath {
     grep -q 'export PATH=$HOME/bin:$PATH' "$bashPath" || echo -e '\nexport PATH=$HOME/bin:$PATH' >> "$bashPath"
   } || { # catch
     echoerr
-    echoerr "Failed to add $HOME/bin to PATH.  Update your $bashPath by running the following command:"
+    echoerr "Failed to add $HOME/bin to PATH. Please update your $bashPath by running the following command:"
     echoerr "  export PATH=\$HOME/bin:\$PATH >> $bashPath"
   }
 }
@@ -112,7 +112,7 @@ function updateZshPath {
     grep -q 'export PATH=$HOME/bin:$PATH' ~/.zshrc || echo -e '\nexport PATH=$HOME/bin:$PATH' >> ~/.zshrc
   } || { # catch
     echoerr
-    echoerr 'Failed to add $HOME/bin to PATH.  Update your ~/.zshrc will by running the following command:'
+    echoerr 'Failed to add $HOME/bin to PATH. Please update your ~/.zshrc by running the following command:'
     echoerr '  export PATH=$HOME/bin:$PATH >> ~/.zshrc'
   }
 }

--- a/cli/src/main/scripts/install.sh
+++ b/cli/src/main/scripts/install.sh
@@ -74,7 +74,8 @@ function install {
 
   PATH_UPDATED=false
   if [[ ! "$LOCATION" == *"$HOME/bin/okta:"* ]]; then
-    [ -f $HOME/.bashrc ] && updateBashPath && PATH_UPDATED=true
+    [ -f $HOME/.bash_profile ] && updateBashProfilePath && PATH_UPDATED=true
+    [ -f $HOME/.bashrc ] && updateBashRcPath && PATH_UPDATED=true
     [ -f $HOME/.zshrc ] && updateZshPath && PATH_UPDATED=true
 
     if [[ ! "$PATH_UPDATED" == "true" ]]; then
@@ -85,13 +86,22 @@ function install {
 }
 
 function updateBashPath {
+  local bashPath=$1
   { # try
-    grep -q 'export PATH=$HOME/bin:$PATH' ~/.bashrc || echo -e '\nexport PATH=$HOME/bin:$PATH' >> ~/.bashrc
+    grep -q 'export PATH=$HOME/bin:$PATH' "$bashPath" || echo -e '\nexport PATH=$HOME/bin:$PATH' >> "$bashPath"
   } || { # catch
     echoerr
-    echoerr 'Failed add $HOME/bin to PATH.  Update your ~/.bashrc will by running the following command:'
-    echoerr '  export PATH=$HOME/bin:$PATH >> ~/.bashrc'
+    echoerr "Failed add $HOME/bin to PATH.  Update your $bashPath by running the following command:"
+    echoerr "  export PATH=\$HOME/bin:\$PATH >> $bashPath"
   }
+}
+
+function updateBashProfilePath {
+  updateBashPath "~/.bash_profile"
+}
+
+function updateBashRcPath {
+  updateBashPath "~/.bashrc"
 }
 
 function updateZshPath {

--- a/cli/src/main/scripts/install.sh
+++ b/cli/src/main/scripts/install.sh
@@ -64,7 +64,7 @@ function install {
 
   } || { # catch
      echoerr
-     echoerr "Failed install the okta cli, run the following command manually:"
+     echoerr "Failed to install the okta cli.  Run the following command manually:"
      echoerr "  mv -f $DOWNLOAD_LOCATION $HOME/bin"
      exit 1
   }
@@ -74,34 +74,37 @@ function install {
 
   PATH_UPDATED=false
   if [[ ! "$LOCATION" == *"$HOME/bin/okta:"* ]]; then
-    [ -f $HOME/.bash_profile ] && updateBashProfilePath && PATH_UPDATED=true
-    [ -f $HOME/.bashrc ] && updateBashRcPath && PATH_UPDATED=true
-    [ -f $HOME/.zshrc ] && updateZshPath && PATH_UPDATED=true
+    [ -f "$HOME/.bash_profile" ] && updateBashProfilePath && PATH_UPDATED=true
+    [ -f "$HOME/.bashrc" ] && updateBashRcPath && PATH_UPDATED=true
+    [ -f "$HOME/.zshrc" ] && updateZshPath && PATH_UPDATED=true
 
     if [[ ! "$PATH_UPDATED" == "true" ]]; then
-      echoerr "Failed to add \$HOME/bin/okta to your path"
+      echoerr 'Failed to add $HOME/bin/okta to your path'
       exit 1
     fi
   fi
 }
 
 function updateBashPath {
+  # shellcheck disable=SC2016
+  (( $# == 1 )) || { printf 'Usage: updateBashPath $bashPath\n' >&2; return 1; }
+
   local bashPath=$1
   { # try
     grep -q 'export PATH=$HOME/bin:$PATH' "$bashPath" || echo -e '\nexport PATH=$HOME/bin:$PATH' >> "$bashPath"
   } || { # catch
     echoerr
-    echoerr "Failed add $HOME/bin to PATH.  Update your $bashPath by running the following command:"
+    echoerr "Failed to add $HOME/bin to PATH.  Update your $bashPath by running the following command:"
     echoerr "  export PATH=\$HOME/bin:\$PATH >> $bashPath"
   }
 }
 
 function updateBashProfilePath {
-  updateBashPath "~/.bash_profile"
+  updateBashPath "$HOME/.bash_profile"
 }
 
 function updateBashRcPath {
-  updateBashPath "~/.bashrc"
+  updateBashPath "$HOME/.bashrc"
 }
 
 function updateZshPath {
@@ -109,7 +112,7 @@ function updateZshPath {
     grep -q 'export PATH=$HOME/bin:$PATH' ~/.zshrc || echo -e '\nexport PATH=$HOME/bin:$PATH' >> ~/.zshrc
   } || { # catch
     echoerr
-    echoerr 'Failed add $HOME/bin to PATH.  Update your ~/.zshrc will by running the following command:'
+    echoerr 'Failed to add $HOME/bin to PATH.  Update your ~/.zshrc will by running the following command:'
     echoerr '  export PATH=$HOME/bin:$PATH >> ~/.zshrc'
   }
 }


### PR DESCRIPTION
The existing install script failed on my Macbook (OSX). The script was expecting .bashrc but this Macbook, which is completely vanilla afaik, uses .bash_profile. .bashrc actually does not appear to get sourced by VS Code bash terminals, so perhaps .bash_profile is more correct, but in any case the script should support both (I checked).

Also ...
tilde ('~') was failing so I replaced ~ with $HOME in my changes, though not elsewhere.
I made grammar fixes to a few of the error messages
I used quotes in my changes to make shellcheck happy, though I did not attempt to fix all shellcheck issues with the existing code.

