### PR TITLE
Upgrade SnakeYAML and Okta Java Mgmt SDK versions

### DIFF
--- a/common/src/main/java/com/okta/cli/common/config/YamlPropertiesSource.java
+++ b/common/src/main/java/com/okta/cli/common/config/YamlPropertiesSource.java
@@ -20,7 +20,7 @@ import com.okta.sdk.impl.io.FileResource;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 import org.yaml.snakeyaml.representer.Representer;
 
 import java.io.File;
@@ -50,7 +50,7 @@ public class YamlPropertiesSource extends WrappedMutablePropertiesSource {
     @Override
     public void addProperties(Map<String, String> properties) throws IOException {
 
-        Yaml springAppYaml = new Yaml(new Constructor(Map.class, new LoaderOptions()), new Representer(yamlOptions()));
+        Yaml springAppYaml = new Yaml(new SafeConstructor(new LoaderOptions()), new Representer(yamlOptions()));
         Map<String, Object> existingProperties = new HashMap<>();
         if (yamlFile.exists()) {
             try (Reader reader = new InputStreamReader(new FileInputStream(yamlFile), StandardCharsets.UTF_8)) {

--- a/common/src/main/java/com/okta/cli/common/config/YamlPropertiesSource.java
+++ b/common/src/main/java/com/okta/cli/common/config/YamlPropertiesSource.java
@@ -15,11 +15,13 @@
  */
 package com.okta.cli.common.config;
 
+import com.okta.commons.lang.Strings;
 import com.okta.sdk.impl.config.YAMLPropertiesSource;
 import com.okta.sdk.impl.io.FileResource;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 import org.yaml.snakeyaml.representer.Representer;
 
@@ -30,7 +32,9 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class YamlPropertiesSource extends WrappedMutablePropertiesSource {
@@ -92,6 +96,79 @@ public class YamlPropertiesSource extends WrappedMutablePropertiesSource {
         }
         try (Writer writer = fileWriter(yamlFile)) {
             springAppYaml.dump(existingProperties, writer);
+        }
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        Map<String, Object> existingProperties;
+
+        try {
+            Yaml springAppYaml = new Yaml(new Constructor(Map.class, new LoaderOptions()), new Representer(yamlOptions()));
+            existingProperties = new HashMap<>();
+            if (yamlFile.exists()) {
+                try (Reader reader = new InputStreamReader(new FileInputStream(yamlFile), StandardCharsets.UTF_8)) {
+                    Map<? extends String, Object> loadedProperties = springAppYaml.load(reader);
+
+                    // null if the file is empty
+                    if (loadedProperties != null) {
+                        existingProperties.putAll(loadedProperties);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Unable to read yaml [" + this.yamlFile + "]: " + e.getMessage(), e);
+        }
+
+        return getFlattenedMap(existingProperties);
+    }
+
+    /**
+     * Return a flattened version of the given map, recursively following any nested Map
+     * or Collection values. Entries from the resulting map retain the same order as the
+     * source.
+     *
+     * Copied from https://github.com/spring-projects/spring-framework/blob/master/spring-beans/src/main/java/org/springframework/beans/factory/config/YamlProcessor.java
+     *
+     * @param source the source map
+     * @return a flattened map
+     */
+    private static Map<String, String> getFlattenedMap(Map<String, Object> source) {
+        Map<String, String> result = new LinkedHashMap<>();
+        buildFlattenedMap(result, source, null);
+        return result;
+    }
+
+    private static void buildFlattenedMap(Map<String, String> result, Map<String, Object> source, String path) {
+        for (Map.Entry<String, Object> entry : source.entrySet()) {
+            String key = entry.getKey();
+            if (Strings.hasText(path)) {
+                if (key.startsWith("[")) {
+                    key = path + key;
+                }
+                else {
+                    key = path + "." + key;
+                }
+            }
+            Object value = entry.getValue();
+            if (value instanceof String) {
+                result.put(key, String.valueOf(value));
+            }
+            else if (value instanceof Map) {
+                // Need a compound key
+                @SuppressWarnings("unchecked")
+                Map<String, Object> map = (Map<String, Object>) value;
+                buildFlattenedMap(result, map, key);
+            }
+            else if (value instanceof Collection) {
+                // Need a compound key
+                @SuppressWarnings("unchecked")
+                Collection<Object> collection = (Collection<Object>) value;
+                result.put(key, Strings.collectionToCommaDelimitedString(collection));
+            }
+            else {
+                result.put(key, value != null ? String.valueOf(value) : "");
+            }
         }
     }
 

--- a/common/src/main/java/com/okta/cli/common/config/YamlPropertiesSource.java
+++ b/common/src/main/java/com/okta/cli/common/config/YamlPropertiesSource.java
@@ -18,6 +18,7 @@ package com.okta.cli.common.config;
 import com.okta.sdk.impl.config.YAMLPropertiesSource;
 import com.okta.sdk.impl.io.FileResource;
 import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.representer.Representer;
@@ -49,7 +50,7 @@ public class YamlPropertiesSource extends WrappedMutablePropertiesSource {
     @Override
     public void addProperties(Map<String, String> properties) throws IOException {
 
-        Yaml springAppYaml = new Yaml(new Constructor(Map.class), new Representer(yamlOptions()));
+        Yaml springAppYaml = new Yaml(new Constructor(Map.class, new LoaderOptions()), new Representer(yamlOptions()));
         Map<String, Object> existingProperties = new HashMap<>();
         if (yamlFile.exists()) {
             try (Reader reader = new InputStreamReader(new FileInputStream(yamlFile), StandardCharsets.UTF_8)) {

--- a/common/src/main/java/com/okta/cli/common/service/DefaultSampleConfigParser.java
+++ b/common/src/main/java/com/okta/cli/common/service/DefaultSampleConfigParser.java
@@ -17,6 +17,7 @@ package com.okta.cli.common.service;
 
 import com.okta.cli.common.model.OktaSampleConfig;
 import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.representer.Representer;
@@ -50,7 +51,7 @@ public class DefaultSampleConfigParser implements SampleConfigParser {
         Representer representer = new Representer(new DumperOptions());
         representer.getPropertyUtils().setSkipMissingProperties(true);
 
-        OktaSampleConfig config = new Yaml(new Constructor(OktaSampleConfig.class), representer).loadAs(configFileContent, OktaSampleConfig.class);
+        OktaSampleConfig config = new Yaml(new Constructor(OktaSampleConfig.class, new LoaderOptions()), representer).loadAs(configFileContent, OktaSampleConfig.class);
 
         // TODO improve validation of configuration
         if (config.getOAuthClient() == null) {

--- a/common/src/main/java/com/okta/cli/common/service/DefaultSampleConfigParser.java
+++ b/common/src/main/java/com/okta/cli/common/service/DefaultSampleConfigParser.java
@@ -19,7 +19,7 @@ import com.okta.cli.common.model.OktaSampleConfig;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.constructor.SafeConstructor;
+import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.representer.Representer;
 
 import java.io.File;
@@ -51,7 +51,7 @@ public class DefaultSampleConfigParser implements SampleConfigParser {
         Representer representer = new Representer(new DumperOptions());
         representer.getPropertyUtils().setSkipMissingProperties(true);
 
-        OktaSampleConfig config = new Yaml(new SafeConstructor(new LoaderOptions()), representer).loadAs(configFileContent, OktaSampleConfig.class);
+        OktaSampleConfig config = new Yaml(new Constructor(OktaSampleConfig.class, new LoaderOptions()), representer).loadAs(configFileContent, OktaSampleConfig.class);
 
         // TODO improve validation of configuration
         if (config.getOAuthClient() == null) {

--- a/common/src/main/java/com/okta/cli/common/service/DefaultSampleConfigParser.java
+++ b/common/src/main/java/com/okta/cli/common/service/DefaultSampleConfigParser.java
@@ -19,7 +19,7 @@ import com.okta.cli.common.model.OktaSampleConfig;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 import org.yaml.snakeyaml.representer.Representer;
 
 import java.io.File;
@@ -51,7 +51,7 @@ public class DefaultSampleConfigParser implements SampleConfigParser {
         Representer representer = new Representer(new DumperOptions());
         representer.getPropertyUtils().setSkipMissingProperties(true);
 
-        OktaSampleConfig config = new Yaml(new Constructor(OktaSampleConfig.class, new LoaderOptions()), representer).loadAs(configFileContent, OktaSampleConfig.class);
+        OktaSampleConfig config = new Yaml(new SafeConstructor(new LoaderOptions()), representer).loadAs(configFileContent, OktaSampleConfig.class);
 
         // TODO improve validation of configuration
         if (config.getOAuthClient() == null) {

--- a/common/src/test/groovy/com/okta/cli/common/TestUtil.groovy
+++ b/common/src/test/groovy/com/okta/cli/common/TestUtil.groovy
@@ -18,7 +18,7 @@ package com.okta.cli.common
 import org.testng.Assert
 import org.yaml.snakeyaml.LoaderOptions
 import org.yaml.snakeyaml.Yaml
-import org.yaml.snakeyaml.constructor.SafeConstructor
+import org.yaml.snakeyaml.constructor.Constructor
 
 class TestUtil {
 
@@ -36,7 +36,7 @@ class TestUtil {
 
     static Map readYamlFromFile(File configFile) {
         configFile.withReader {
-            return new Yaml(new SafeConstructor(new LoaderOptions())).loadAs(it, Map)
+            return new Yaml(new Constructor(Map.class, new LoaderOptions())).loadAs(it, Map)
         }
     }
 

--- a/common/src/test/groovy/com/okta/cli/common/TestUtil.groovy
+++ b/common/src/test/groovy/com/okta/cli/common/TestUtil.groovy
@@ -16,6 +16,7 @@
 package com.okta.cli.common
 
 import org.testng.Assert
+import org.yaml.snakeyaml.LoaderOptions
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.constructor.Constructor
 
@@ -35,7 +36,7 @@ class TestUtil {
 
     static Map readYamlFromFile(File configFile) {
         configFile.withReader {
-            return new Yaml(new Constructor(Map)).loadAs(it, Map)
+            return new Yaml(new Constructor(Map, new LoaderOptions())).loadAs(it, Map)
         }
     }
 

--- a/common/src/test/groovy/com/okta/cli/common/TestUtil.groovy
+++ b/common/src/test/groovy/com/okta/cli/common/TestUtil.groovy
@@ -18,7 +18,7 @@ package com.okta.cli.common
 import org.testng.Assert
 import org.yaml.snakeyaml.LoaderOptions
 import org.yaml.snakeyaml.Yaml
-import org.yaml.snakeyaml.constructor.Constructor
+import org.yaml.snakeyaml.constructor.SafeConstructor
 
 class TestUtil {
 
@@ -36,7 +36,7 @@ class TestUtil {
 
     static Map readYamlFromFile(File configFile) {
         configFile.withReader {
-            return new Yaml(new Constructor(Map, new LoaderOptions())).loadAs(it, Map)
+            return new Yaml(new SafeConstructor(new LoaderOptions())).loadAs(it, Map)
         }
     }
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -30,19 +30,19 @@
         <dependency>
             <groupId>com.okta.sdk</groupId>
             <artifactId>okta-sdk-api</artifactId>
-            <version>8.2.2</version>
+            <version>${okta.sdk.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.okta.sdk</groupId>
             <artifactId>okta-sdk-impl</artifactId>
-            <version>8.2.2</version>
+            <version>${okta.sdk.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.okta.sdk</groupId>
             <artifactId>okta-sdk-httpclient</artifactId>
-            <version>8.2.2</version>
+            <version>${okta.sdk.version}</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/integration-tests/src/test/groovy/com/okta/cli/test/CreateAppSupport.groovy
+++ b/integration-tests/src/test/groovy/com/okta/cli/test/CreateAppSupport.groovy
@@ -28,6 +28,7 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.RecordedRequest
 import org.hamcrest.Matcher
 import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.LoaderOptions
 import org.yaml.snakeyaml.constructor.Constructor
 
 import java.nio.charset.StandardCharsets
@@ -69,7 +70,7 @@ trait CreateAppSupport {
     }
 
     Map parseYaml(File oktaConfigFile) {
-        Yaml yaml = new Yaml(new Constructor(Map))
+        Yaml yaml = new Yaml(new Constructor(Map.class, new LoaderOptions()))
         return yaml.load(oktaConfigFile.text)
     }
 

--- a/integration-tests/src/test/groovy/com/okta/cli/test/OktaConfigMatcher.groovy
+++ b/integration-tests/src/test/groovy/com/okta/cli/test/OktaConfigMatcher.groovy
@@ -19,6 +19,7 @@ import org.hamcrest.Description
 import org.hamcrest.TypeSafeMatcher
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.constructor.Constructor
+import org.yaml.snakeyaml.LoaderOptions
 
 class OktaConfigMatcher extends TypeSafeMatcher<File> {
 
@@ -54,7 +55,7 @@ class OktaConfigMatcher extends TypeSafeMatcher<File> {
     }
 
     private static Map parseYaml(File oktaConfigFile) {
-        Yaml yaml = new Yaml(new Constructor(Map))
+        Yaml yaml = new Yaml(new Constructor(Map.class, new LoaderOptions()))
         return yaml.load(oktaConfigFile.text)
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <okta.sdk.version>8.2.2</okta.sdk.version>
+        <okta.sdk.version>8.2.4</okta.sdk.version>
         <slf4j.version>2.0.7</slf4j.version>
     </properties>
 
@@ -92,7 +92,7 @@
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
-                <version>1.33</version>
+                <version>2.0</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>


### PR DESCRIPTION
- Upgrade SnakeYAML from 1.33 to 2.0
- Upgrade Okta Java Mgmt SDK dependency from 8.2.2 to 8.2.4