### PR TITLE
Bump Okta Java SDK version from `8.2.4` to `8.2.5`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <okta.sdk.version>8.2.4</okta.sdk.version>
+        <okta.sdk.version>8.2.5</okta.sdk.version>
         <slf4j.version>2.0.9</slf4j.version>
     </properties>
 


### PR DESCRIPTION
https://oktainc.atlassian.net/browse/OKTA-627649

This upgrade will ensure we have moved away `org.bouncycastle:bcprov-jdk15on` to use `org.bouncycastle:bcprov-jdk18on`. 