### PR TITLE
Upgrade graal-sdk to 24.0.1 to fix Snyk-reported vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
             <dependency>
                 <groupId>org.graalvm.sdk</groupId>
                 <artifactId>graal-sdk</artifactId>
-                <version>22.3.5</version>
+                <version>24.0.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
This PR updates the `org.graalvm.sdk:graal-sdk` dependency from version `22.3.5` to `24.0.1` to remediate multiple vulnerabilities identified by Snyk.