### PR TITLE
Upgrade commons-lang3 to 3.18.0 to fix CVE-2025-48924

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,11 @@
                 <artifactId>commons-io</artifactId>
                 <version>2.14.0</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.18.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
This PR addresses a high-severity vulnerability (CVE-2025-48924) reported by Snyk in `commons-lang3` v3.14.0, introduced transitively via `commons-compress`. The `dependencyManagement` section has been updated to force `commons-lang3` to version 3.18.0, which includes the necessary security fix. 