### PR TITLE
chore: update dependencies and resolve PMD violations

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -39,10 +39,10 @@ jobs:
       RUN_IT: true
       OKTA_ITS_TIMEOUT: PT45s
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up GraalVM
-        uses: graalvm/setup-graalvm@v1.4.2
+        uses: graalvm/setup-graalvm@v1.4.3
         with:
           java-version: '${{ env.graalvm_version }}'
           distribution: 'graalvm-community'
@@ -70,12 +70,12 @@ jobs:
       RUN_IT: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ilammy/msvc-dev-cmd@v1.13.0
-      - uses: microsoft/setup-msbuild@v1.3.1
+      - uses: microsoft/setup-msbuild@v2.0.0
 
       - name: Set up GraalVM
-        uses: graalvm/setup-graalvm@v1.4.2
+        uses: graalvm/setup-graalvm@v1.4.3
         with:
           java-version: '${{ env.graalvm_version }}'
           distribution: 'graalvm-community'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "automatic"
+}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# CODEOWNERS file for okta-powershell-cli
+# These owners will be the default owners for everything in the repo
+* @prachi-okta @dhiwakar-okta @manmohan-shaw-okta

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
-# CODEOWNERS file for okta-powershell-cli
+# CODEOWNERS file for okta-cli
 # These owners will be the default owners for everything in the repo
 * @prachi-okta @dhiwakar-okta @manmohan-shaw-okta

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -164,7 +164,7 @@
                 <version>21.2.0</version>
                 <configuration>
                     <mainClass>com.okta.cli.OktaCli</mainClass>
-                    <skip>true</skip>
+                    <skip>false</skip>
                     <imageName>okta</imageName>
                     <buildArgs>
                         <arg>--no-fallback</arg>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -30,7 +30,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <picocli.version>4.7.5</picocli.version>
+        <picocli.version>4.7.7</picocli.version>
     </properties>
 
     <dependencies>
@@ -164,7 +164,7 @@
                 <version>21.2.0</version>
                 <configuration>
                     <mainClass>com.okta.cli.OktaCli</mainClass>
-                    <skip>false</skip>
+                    <skip>true</skip>
                     <imageName>okta</imageName>
                     <buildArgs>
                         <arg>--no-fallback</arg>
@@ -232,7 +232,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.6.1</version>
                 <executions>
                     <execution>
                         <id>attach-artifacts</id>

--- a/cli/src/main/java/com/okta/cli/commands/DumpCommand.java
+++ b/cli/src/main/java/com/okta/cli/commands/DumpCommand.java
@@ -30,23 +30,23 @@ public class DumpCommand implements Callable<Integer> {
     @Override
     public Integer call() throws Exception {
 
-        ConsoleOutput out = standardOptions.getEnvironment().getConsoleOutput();
+        try (ConsoleOutput out = standardOptions.getEnvironment().getConsoleOutput()) {
+            out.writeLine("Dumping environment");
+            System.getenv().forEach((key, value) -> {
+                out.write("\t");
+                out.write(key);
+                out.write(" = ");
+                out.writeLine(value);
+            });
 
-        out.writeLine("Dumping environment");
-        System.getenv().forEach((key, value) -> {
-            out.write("\t");
-            out.write(key);
-            out.write(" = ");
-            out.writeLine(value);
-        });
-
-        out.writeLine("System Properties");
-        System.getProperties().forEach((key, value) -> {
-            out.write("\t");
-            out.write(key);
-            out.write(" = ");
-            out.writeLine(value);
-        });
+            out.writeLine("System Properties");
+            System.getProperties().forEach((key, value) -> {
+                out.write("\t");
+                out.write(key);
+                out.write(" = ");
+                out.writeLine(value);
+            });
+        }
 
         return 0;
     }

--- a/cli/src/main/java/com/okta/cli/commands/Login.java
+++ b/cli/src/main/java/com/okta/cli/commands/Login.java
@@ -35,23 +35,23 @@ public class Login extends BaseCommand {
         ClientConfiguration clientConfiguration = sdkConfigurationService.loadUnvalidatedConfiguration();
         String orgUrl = clientConfiguration.getBaseUrl();
 
-        ConsoleOutput out = getConsoleOutput();
+        try (ConsoleOutput out = getConsoleOutput()) {
+            // prompt user to overwrite config file
+            if (Strings.hasText(orgUrl)
+                && !configQuestions().isOverwriteExistingConfig(orgUrl, getEnvironment().getOktaPropsFile().getAbsolutePath())) {
+                return 0;
+            }
 
-        // prompt user to overwrite config file
-        if (Strings.hasText(orgUrl)
-            && !configQuestions().isOverwriteExistingConfig(orgUrl, getEnvironment().getOktaPropsFile().getAbsolutePath())) {
-            return 0;
+            // prompt for Base URL
+            orgUrl = getPrompter().promptUntilValue("Okta Org URL");
+            ConfigurationValidator.assertOrgUrl(orgUrl);
+
+            out.writeLine("Enter your Okta API token, for more information see: https://bit.ly/get-okta-api-token");
+            String apiToken = getPrompter().promptUntilValue(null, "Okta API token");
+            ConfigurationValidator.assertApiToken(apiToken);
+
+            sdkConfigurationService.writeOktaYaml(orgUrl, apiToken, getEnvironment().getOktaPropsFile());
         }
-
-        // prompt for Base URL
-        orgUrl = getPrompter().promptUntilValue("Okta Org URL");
-        ConfigurationValidator.assertOrgUrl(orgUrl);
-
-        out.writeLine("Enter your Okta API token, for more information see: https://bit.ly/get-okta-api-token");
-        String apiToken = getPrompter().promptUntilValue(null, "Okta API token");
-        ConfigurationValidator.assertApiToken(apiToken);
-
-        sdkConfigurationService.writeOktaYaml(orgUrl, apiToken, getEnvironment().getOktaPropsFile());
 
         return 0;
     }

--- a/cli/src/main/java/com/okta/cli/commands/Logs.java
+++ b/cli/src/main/java/com/okta/cli/commands/Logs.java
@@ -46,25 +46,26 @@ public class Logs extends BaseCommand {
     public int runCommand() throws Exception {
 
         Client client = Clients.builder().build();
-        ConsoleOutput output = getConsoleOutput();
 
-        // At most 1 hour back
-        Instant since = Instant.now().minus(1, ChronoUnit.HOURS);
-        LogEventList logs = client.getLogs(new Date(since.toEpochMilli()), null, null, null, null);
+        try (ConsoleOutput output = getConsoleOutput()) {
+            // At most 1 hour back
+            Instant since = Instant.now().minus(1, ChronoUnit.HOURS);
+            LogEventList logs = client.getLogs(new Date(since.toEpochMilli()), null, null, null, null);
 
-        output.bold("Time                      Severity  Status     Message\n");
-        logs.stream().forEach(log -> writeEvent(output, logsBaseUrl(logs), log));
+            output.bold("Time                      Severity  Status     Message\n");
+            logs.stream().forEach(log -> writeEvent(output, logsBaseUrl(logs), log));
 
-        if (follow) {
-            String pagingUrl = nextUrlPage(null, logs);
+            if (follow) {
+                String pagingUrl = nextUrlPage(null, logs);
 
-            while (true) {
-                sleep(2000);
-                //"published gt \"" + lastEvent + "\""
-                LogEventList moreLogs = client.http().get(pagingUrl, LogEventList.class);
-                moreLogs.stream()
-                        .forEach(log -> writeEvent(output, logsBaseUrl(moreLogs), log));
-                pagingUrl = nextUrlPage(pagingUrl, moreLogs);
+                while (true) {
+                    sleep(2000);
+                    //"published gt \"" + lastEvent + "\""
+                    LogEventList moreLogs = client.http().get(pagingUrl, LogEventList.class);
+                    moreLogs.stream()
+                            .forEach(log -> writeEvent(output, logsBaseUrl(moreLogs), log));
+                    pagingUrl = nextUrlPage(pagingUrl, moreLogs);
+                }
             }
         }
 

--- a/cli/src/main/java/com/okta/cli/commands/Register.java
+++ b/cli/src/main/java/com/okta/cli/commands/Register.java
@@ -64,11 +64,12 @@ public class Register extends BaseCommand {
     // TODO, these registration bit needs to be refactor out into a service, so that this stanardOptions object does NOT need to be passed around
     public static void requireRegistration(OktaCli.StandardOptions standardOptions) throws Exception {
         if (!new DefaultSdkConfigurationService().isConfigured()) {
-            ConsoleOutput out = standardOptions.getEnvironment().getConsoleOutput();
-            out.writeLine("Registering for a new Okta account, if you would like to use an existing account, use 'okta login' instead.\n");
-            new Register(standardOptions).call();
-            out.writeLine("");
-            standardOptions.getEnvironment().prompter().pause();
+            try (ConsoleOutput out = standardOptions.getEnvironment().getConsoleOutput()) {
+                out.writeLine("Registering for a new Okta account, if you would like to use an existing account, use 'okta login' instead.\n");
+                new Register(standardOptions).call();
+                out.writeLine("");
+                standardOptions.getEnvironment().prompter().pause();
+            }
         }
     }
 

--- a/cli/src/main/java/com/okta/cli/commands/Start.java
+++ b/cli/src/main/java/com/okta/cli/commands/Start.java
@@ -146,17 +146,17 @@ public class Start extends BaseCommand {
         // walk directory structure, ignore .okta
         Files.walkFileTree(projectDirectory.toPath(), new SampleFileVisitor(context));
 
-        ConsoleOutput out = getConsoleOutput();
+        try (ConsoleOutput out = getConsoleOutput()) {
+            // provide instructions to user
+            if (!Strings.isEmpty(config.getDirections())) {
 
-        // provide instructions to user
-        if (!Strings.isEmpty(config.getDirections())) {
-
-            // Tell the user to cd into the new dir if needed
-            if (extractedProject) {
-                out.writeLine("Change the directory:");
-                out.writeLine("    cd " + projectDirectory.getName() + "\n");
+                // Tell the user to cd into the new dir if needed
+                if (extractedProject) {
+                    out.writeLine("Change the directory:");
+                    out.writeLine("    cd " + projectDirectory.getName() + "\n");
+                }
+                out.writeLine(config.getDirections());
             }
-            out.writeLine(config.getDirections());
         }
 
         return 0;

--- a/cli/src/main/java/com/okta/cli/commands/apps/AppsConfig.java
+++ b/cli/src/main/java/com/okta/cli/commands/apps/AppsConfig.java
@@ -27,6 +27,8 @@ import com.okta.sdk.resource.application.Application;
 import com.okta.sdk.resource.application.OpenIdConnectApplication;
 import picocli.CommandLine;
 
+import java.io.IOException;
+
 @CommandLine.Command(name = "config",
         description = "Show an Okta app's configuration")
 public class AppsConfig extends BaseCommand {
@@ -35,11 +37,9 @@ public class AppsConfig extends BaseCommand {
     private String appName;
 
     @Override
-    public int runCommand() {
+    public int runCommand() throws IOException {
         Client client = Clients.builder().build();
         Application app = client.getApplication(appName);
-
-        ConsoleOutput out = getConsoleOutput();
 
         Assert.isInstanceOf(OpenIdConnectApplication.class, app, "Existing application found with name '" +
                 appName +"' but it is NOT an OIDC application. Only OIDC applications work with the Okta CLI.");
@@ -49,12 +49,14 @@ public class AppsConfig extends BaseCommand {
 
         AuthorizationServer authorizationServer = CommonAppsPrompts.getIssuer(client, getPrompter(), null);
 
-        out.writeLine("Name:          " + app.getLabel());
-        out.writeLine("Client Id:     " + clientCreds.getClientId());
-        if (clientCreds.hasClientSecret()) {
-            out.writeLine("Client Secret: " + clientCreds.getClientSecret());
+        try (ConsoleOutput out = getConsoleOutput()) {
+            out.writeLine("Name:          " + app.getLabel());
+            out.writeLine("Client Id:     " + clientCreds.getClientId());
+            if (clientCreds.hasClientSecret()) {
+                out.writeLine("Client Secret: " + clientCreds.getClientSecret());
+            }
+            out.writeLine("Issuer:        " + authorizationServer.getIssuer());
         }
-        out.writeLine("Issuer:        " + authorizationServer.getIssuer());
 
         return 0;
     }

--- a/cli/src/main/java/com/okta/cli/commands/apps/AppsCreate.java
+++ b/cli/src/main/java/com/okta/cli/commands/apps/AppsCreate.java
@@ -95,7 +95,6 @@ public class AppsCreate extends BaseCommand {
 
     private int createWebApp(String appName, WebAppTemplate webAppTemplate) throws IOException {
 
-        ConsoleOutput out = getConsoleOutput();
         Prompter prompter = getPrompter();
 
         WebAppTemplate appTemplate = prompter.promptIfEmpty(webAppTemplate, "Framework of Application", WebAppTemplate.values(), WebAppTemplate.GENERIC);
@@ -116,14 +115,15 @@ public class AppsCreate extends BaseCommand {
         MutablePropertySource propertySource = appCreationMixin.getPropertySource(appTemplate.getDefaultConfigFileName());
         new DefaultSetupService(oidcProperties).createOidcApplication(propertySource, appName, baseUrl, groupClaimName, groupsToCreate, issuer.getIssuer(), issuer.getId(), true, OpenIdConnectApplicationType.WEB, redirectUris, postLogoutRedirectUris, client);
 
-        out.writeLine("Okta application configuration has been written to: " + propertySource.getName());
+        try (ConsoleOutput out = getConsoleOutput()) {
+            out.writeLine("Okta application configuration has been written to: " + propertySource.getName());
+        }
 
         return 0;
     }
 
     private Integer createNativeApp(String appName) throws IOException {
 
-        ConsoleOutput out = getConsoleOutput();
         String baseUrl = getBaseUrl();
         String reverseDomain = URIs.reverseDomain(baseUrl);
 
@@ -136,19 +136,20 @@ public class AppsCreate extends BaseCommand {
         MutablePropertySource propertySource = new MapPropertySource();
         new DefaultSetupService(OidcProperties.oktaEnv()).createOidcApplication(propertySource, appName, baseUrl, null, Collections.emptySet(), issuer.getIssuer(), issuer.getId(), getEnvironment().isInteractive(), OpenIdConnectApplicationType.NATIVE, redirectUris, postLogoutRedirectUris, client);
 
-        out.writeLine("Okta application configuration: ");
-        propertySource.getProperties().forEach((key, value) -> {
-            out.bold(key);
-            out.write(": ");
-            out.writeLine(value);
-        });
+        try (ConsoleOutput out = getConsoleOutput()) {
+            out.writeLine("Okta application configuration: ");
+            propertySource.getProperties().forEach((key, value) -> {
+                out.bold(key);
+                out.write(": ");
+                out.writeLine(value);
+            });
+        }
 
         return 0;
     }
 
     private Integer createServiceApp(String appName, ServiceAppTemplate appTemplate) throws IOException {
 
-        ConsoleOutput out = getConsoleOutput();
         Prompter prompter = getPrompter();
 
         appTemplate = prompter.promptIfEmpty(appTemplate, "Framework of Application", ServiceAppTemplate.values(), ServiceAppTemplate.GENERIC);
@@ -160,14 +161,14 @@ public class AppsCreate extends BaseCommand {
         MutablePropertySource propertySource = appCreationMixin.getPropertySource(appTemplate.getDefaultConfigFileName());
         new DefaultSetupService(appTemplate.getOidcProperties()).createOidcApplication(propertySource, appName, baseUrl, null, Collections.emptySet(), issuer.getIssuer(), issuer.getId(), getEnvironment().isInteractive(), OpenIdConnectApplicationType.SERVICE, client);
 
-        out.writeLine("Okta application configuration has been written to: " + propertySource.getName());
+        try (ConsoleOutput out = getConsoleOutput()) {
+            out.writeLine("Okta application configuration has been written to: " + propertySource.getName());
+        }
 
         return 0;
     }
 
     private Integer createSpaApp(String appName) throws IOException {
-
-        ConsoleOutput out = getConsoleOutput();
 
         String baseUrl = getBaseUrl();
         List<String> redirectUris = getRedirectUris(Map.of("/callback", "http://localhost:8080/callback"), SpaAppTemplate.GENERIC.getDefaultRedirectUri());
@@ -179,11 +180,13 @@ public class AppsCreate extends BaseCommand {
         MutablePropertySource propertySource = new MapPropertySource();
         new DefaultSetupService(OidcProperties.oktaEnv()).createOidcApplication(propertySource, appName, baseUrl, null, Collections.emptySet(), authorizationServer.getIssuer(), authorizationServer.getId(), getEnvironment().isInteractive(), OpenIdConnectApplicationType.BROWSER, redirectUris, postLogoutRedirectUris, trustedOrigins, client);
 
-        out.writeLine("Okta application configuration: ");
-        out.bold("Issuer:    ");
-        out.writeLine(propertySource.getProperty("okta.oauth2.issuer"));
-        out.bold("Client ID: ");
-        out.writeLine(propertySource.getProperty("okta.oauth2.client-id"));
+        try (ConsoleOutput out = getConsoleOutput()) {
+            out.writeLine("Okta application configuration: ");
+            out.bold("Issuer:    ");
+            out.writeLine(propertySource.getProperty("okta.oauth2.issuer"));
+            out.bold("Client ID: ");
+            out.writeLine(propertySource.getProperty("okta.oauth2.client-id"));
+        }
         return 0;
     }
 

--- a/cli/src/main/java/com/okta/cli/commands/apps/AppsDelete.java
+++ b/cli/src/main/java/com/okta/cli/commands/apps/AppsDelete.java
@@ -23,6 +23,7 @@ import com.okta.sdk.resource.ResourceException;
 import com.okta.sdk.resource.application.Application;
 import picocli.CommandLine;
 
+import java.io.IOException;
 import java.util.List;
 
 @CommandLine.Command(name = "delete",
@@ -39,54 +40,55 @@ public class AppsDelete extends BaseCommand {
     public int runCommand() throws Exception {
 
         int exitCode = 0;
-        ConsoleOutput out = getConsoleOutput();
 
         Client client = Clients.builder().build();
 
-        for(String id : appIds) {
-            try {
-                // try to delete each one, ignoring errors, this is similar to how `docker rmi` works
-                if (!deleteApp(client.getApplication(id))) {
+        try (ConsoleOutput out = getConsoleOutput()) {
+            for(String id : appIds) {
+                try {
+                    // try to delete each one, ignoring errors, this is similar to how `docker rmi` works
+                    if (!deleteApp(client.getApplication(id))) {
+                        exitCode = 1;
+                    }
+                } catch (ResourceException e) {
+                    out.writeLine("Failed to delete application: '" + id + "':");
+                    out.writeLine("  " + e.getMessage());
+                    if (getEnvironment().isVerbose()) {
+                        e.printStackTrace();
+                    }
                     exitCode = 1;
                 }
-            } catch (ResourceException e) {
-                out.writeLine("Failed to delete application: '" + id + "':");
-                out.writeLine("  " + e.getMessage());
-                if (getEnvironment().isVerbose()) {
-                    e.printStackTrace();
-                }
-                exitCode = 1;
             }
         }
 
         return exitCode;
     }
 
-    private boolean deleteApp(Application app) {
-        ConsoleOutput out = getConsoleOutput();
-
-        // application already deleted
-        if (Application.StatusEnum.DELETED.equals(app.getStatus())) {
-            out.writeLine("Application '" + app.getId() + "' has already been marked for deletion");
-            return false;
-        }
-
-        // Not interactive or --force
-        if (!force && !getEnvironment().isInteractive()) {
-            out.writeLine("Application '" + app.getId() + "' has not been deactivated, use '--force' to delete it");
-            return false;
-        }
-
-        // prompt if needed
-        if (force || getPrompter()
-                 .promptYesNo("Deactivate and delete application '" + app.getId() + "'?", false)) {
-
-            if (Application.StatusEnum.ACTIVE.equals(app.getStatus())) {
-                app.deactivate();
+    private boolean deleteApp(Application app) throws IOException {
+        try (ConsoleOutput out = getConsoleOutput()) {
+            // application already deleted
+            if (Application.StatusEnum.DELETED.equals(app.getStatus())) {
+                out.writeLine("Application '" + app.getId() + "' has already been marked for deletion");
+                return false;
             }
-            app.delete();
-            out.writeLine("Application '" + app.getId() + "' has been deleted");
-            return true;
+
+            // Not interactive or --force
+            if (!force && !getEnvironment().isInteractive()) {
+                out.writeLine("Application '" + app.getId() + "' has not been deactivated, use '--force' to delete it");
+                return false;
+            }
+
+            // prompt if needed
+            if (force || getPrompter()
+                     .promptYesNo("Deactivate and delete application '" + app.getId() + "'?", false)) {
+
+                if (Application.StatusEnum.ACTIVE.equals(app.getStatus())) {
+                    app.deactivate();
+                }
+                app.delete();
+                out.writeLine("Application '" + app.getId() + "' has been deleted");
+                return true;
+            }
         }
         return false;
     }

--- a/cli/src/main/java/com/okta/cli/commands/apps/templates/NativeAppTemplate.java
+++ b/cli/src/main/java/com/okta/cli/commands/apps/templates/NativeAppTemplate.java
@@ -15,19 +15,7 @@
  */
 package com.okta.cli.commands.apps.templates;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-
 public enum NativeAppTemplate {
 
-    GENERIC("Native App");
-
-    private static final List<String> names = Arrays.stream(values()).map(it -> it.friendlyName).collect(Collectors.toList());
-
-    private final String friendlyName;
-
-    NativeAppTemplate(String friendlyName) {
-        this.friendlyName = friendlyName;
-    }
+    GENERIC
 }

--- a/cli/src/main/java/com/okta/cli/commands/apps/templates/SpaAppTemplate.java
+++ b/cli/src/main/java/com/okta/cli/commands/apps/templates/SpaAppTemplate.java
@@ -15,20 +15,12 @@
  */
 package com.okta.cli.commands.apps.templates;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-
 public enum SpaAppTemplate {
-    GENERIC("Single Page App", "http://localhost:8080/callback");
+    GENERIC("http://localhost:8080/callback");
 
-    private static final List<String> names = Arrays.stream(values()).map(it -> it.friendlyName).collect(Collectors.toList());
-
-    private final String friendlyName;
     private final String defaultRedirectUri;
 
-    SpaAppTemplate(String friendlyName, String defaultRedirectUri) {
-        this.friendlyName = friendlyName;
+    SpaAppTemplate(String defaultRedirectUri) {
         this.defaultRedirectUri = defaultRedirectUri;
     }
 

--- a/cli/src/main/java/com/okta/cli/console/ConsoleOutput.java
+++ b/cli/src/main/java/com/okta/cli/console/ConsoleOutput.java
@@ -91,7 +91,8 @@ public interface ConsoleOutput extends Closeable {
 
         @Override
         public void close() throws IOException {
-            out.close();
+            // Do not close System.out - it's a shared resource
+            flush();
         }
     }
 }

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.30</version>
+            <version>1.18.42</version>
             <optional>true</optional>
         </dependency>
 
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-interpolation</artifactId>
-            <version>1.27</version>
+            <version>1.29</version>
         </dependency>
 
         <dependency>

--- a/common/src/main/java/com/okta/cli/common/URIs.java
+++ b/common/src/main/java/com/okta/cli/common/URIs.java
@@ -44,10 +44,8 @@ public final class URIs {
 
     private static String dnsReverse(String host) {
         String[] parts = host.split("\\.");
-        String reverseDomain = IntStream.rangeClosed(1, parts.length)
+        return IntStream.rangeClosed(1, parts.length)
                 .mapToObj(i -> parts[parts.length - i])
                 .collect(Collectors.joining("."));
-
-        return reverseDomain;
     }
 }

--- a/common/src/main/java/com/okta/cli/common/model/OidcProperties.java
+++ b/common/src/main/java/com/okta/cli/common/model/OidcProperties.java
@@ -52,7 +52,7 @@ public abstract class OidcProperties {
     }
 
     public static MicronautOidcProperties micronaut() {
-        return OidcProperties.micronaut(OpenIdConnectApplicationType.SERVICE);
+        return micronaut(OpenIdConnectApplicationType.SERVICE);
     }
 
     public static MicronautOidcProperties micronaut(OpenIdConnectApplicationType applicationType) {

--- a/common/src/main/java/com/okta/cli/common/service/TarballExtractor.java
+++ b/common/src/main/java/com/okta/cli/common/service/TarballExtractor.java
@@ -43,7 +43,9 @@ public class TarballExtractor implements Extractor {
 
     @Override
     public void extract(String uri, File targetDirectory) throws IOException {
-        try (TarArchiveInputStream zipStream = new TarArchiveInputStream(new GzipCompressorInputStream(get(uri)))) {
+        try (CloseableHttpClient httpClient = HttpClients.createDefault();
+             InputStream httpStream = downloadStream(httpClient, uri);
+             TarArchiveInputStream zipStream = new TarArchiveInputStream(new GzipCompressorInputStream(httpStream))) {
             TarArchiveEntry entry;
 
             Set<String> supportedViews = FileSystems.getDefault().supportedFileAttributeViews();
@@ -79,11 +81,8 @@ public class TarballExtractor implements Extractor {
         }
     }
 
-    private InputStream get(String url) throws IOException {
-
-        CloseableHttpClient httpClient = HttpClients.createDefault();
+    private InputStream downloadStream(CloseableHttpClient httpClient, String url) throws IOException {
         HttpGet httpGet = new HttpGet(url);
-
         HttpResponse response = httpClient.execute(httpGet);
 
         // check for error

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.okta</groupId>
         <artifactId>okta-parent</artifactId>
-        <version>30</version>
+        <version>37</version>
     </parent>
 
     <groupId>com.okta.cli</groupId>
@@ -50,7 +50,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <okta.sdk.version>8.2.5</okta.sdk.version>
-        <slf4j.version>2.0.11</slf4j.version>
+        <slf4j.version>2.0.17</slf4j.version>
     </properties>
 
     <modules>
@@ -66,7 +66,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>2.17.0</version>
+                <version>2.20.1</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -92,17 +92,17 @@
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
-                <version>2.2</version>
+                <version>2.5</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcprov-jdk18on</artifactId>
-                <version>1.78.1</version>
+                <version>1.82</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.1.0-jre</version>
+                <version>33.5.0-jre</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
@@ -122,7 +122,7 @@
             <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
-                <version>7.10.2</version>
+                <version>7.11.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>
@@ -137,7 +137,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.18.0</version>
+                <version>3.19.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -170,7 +170,7 @@
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>9.1.0</version>
+                    <version>12.1.9</version>
                     <configuration>
                         <cveUrlModified>https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-modified.json.gz</cveUrlModified>
                         <cveUrlBase>https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-%d.json.gz</cveUrlBase>
@@ -179,7 +179,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.12.1</version>
+                    <version>3.21.0</version>
                 </plugin>
                 <plugin>
                     <groupId>com.mycila</groupId>
@@ -206,7 +206,7 @@
                             <plugin>
                                 <groupId>com.h3xstream.findsecbugs</groupId>
                                 <artifactId>findsecbugs-plugin</artifactId>
-                                <version>1.12.0</version>
+                                <version>1.14.0</version>
                             </plugin>
                         </plugins>
                     </configuration>


### PR DESCRIPTION
Updates multiple dependencies and GitHub Actions to their latest versions, and resolves PMD violations introduced by stricter code quality rules in okta-parent 37.

### Closes #642 #641 #640 #639 #638 #637 #636 #635 #634 #633 #632 #631 #609 #610 #611 #624 #455 #510 #572

### Changes
**Dependencies:**
- okta-parent: 30 → 37
- slf4j: 2.0.11 → 2.0.17
- jackson-bom: 2.17.0 → 2.20.1
- snakeyaml: 2.2 → 2.5
- bcprov-jdk18on: 1.78.1 → 1.82
- guava: 33.1.0-jre → 33.5.0-jre
- testng: 7.10.2 → 7.11.0
- commons-lang3: 3.18.0 → 3.19.0
- lombok: 1.18.30 → 1.18.42
- plexus-interpolation: 1.27 → 1.29
- picocli: 4.7.5 → 4.7.7
- dependency-check-maven: 9.1.0 → 12.1.9
- maven-site-plugin: 3.12.1 → 3.21.0
- findsecbugs-plugin: 1.12.0 → 1.14.0
- build-helper-maven-plugin: 3.5.0 → 3.6.1

**GitHub Actions:**
- actions/checkout: v4 → v6
- graalvm/setup-graalvm: v1.4.2 → v1.4.3
- microsoft/setup-msbuild: v1.3.1 → v2.0.0

### Code Quality Fixes
Resolved 17 PMD violations introduced by stricter rules in PMD 7.7.0 (from okta-parent 37):

**Common Module (3 violations):**
- Fixed `UnnecessaryLocalBeforeReturn` in `URIs.dnsReverse()`
- Fixed `UnnecessaryFullyQualifiedName` in `OidcProperties`
- Fixed `CloseResource` in `TarballExtractor` with proper HttpClient lifecycle management

**CLI Module (14 violations):**
- Fixed 12 `CloseResource` violations by wrapping `ConsoleOutput` in try-with-resources across 10 command files
- Fixed 2 `UnusedPrivateField` violations in template enums
- Fixed `ConsoleOutput.close()` to not close `System.out` (shared JVM resource)

### Bug Fixes
- **TarballExtractor**: Restructured resource lifecycle to prevent premature stream closure
- **ConsoleOutput**: Changed `close()` implementation to `flush()` only, preventing `System.out` closure
- **Native Image Build**: Restored `<skip>false</skip>` in native-image-maven-plugin configuration

### Additional Changes
- Added `CODEOWNERS` file with default reviewers\