### PR TITLE
fix: upgrade native-image-maven-plugin to 25.0.1 to resolve CVE vulne…

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -161,7 +161,7 @@
             <plugin>
                 <groupId>org.graalvm.nativeimage</groupId>
                 <artifactId>native-image-maven-plugin</artifactId>
-                <version>21.2.0</version>
+                <version>25.0.1</version>
                 <configuration>
                     <mainClass>com.okta.cli.OktaCli</mainClass>
                     <skip>false</skip>


### PR DESCRIPTION


Upgrade native-image-maven-plugin from 21.2.0 to 25.0.1 to address:
- CVE-2025-30691 (Buffer Overflow)
- CVE-2025-30698 (Heap-based Buffer Overflow)
- CVE-2025-21587 (Timing Attack)

The vulnerable component org.graalvm.sdk:graal-sdk@22.3.5 was pulled in as a transitive dependency through the old plugin version.